### PR TITLE
fix: 修复终端粘贴、字体设置和历史滚动

### DIFF
--- a/web/components/panes/TerminalView.tsx
+++ b/web/components/panes/TerminalView.tsx
@@ -14,7 +14,7 @@ import { isDragging } from "@/stores/splitDragState";
 import { replayAttachedSession } from "./terminalReplay";
 import { formatTerminalInitError } from "./terminalInitError";
 import { buildCursorPositionReport } from "./terminalCpr";
-import { resolveTerminalPastePayload } from "./terminalClipboard";
+import { isTerminalPasteShortcut, resolveTerminalPastePayload } from "./terminalClipboard";
 import { createTerminalWriteFlowControl } from "./terminalWriteFlowControl";
 import "@xterm/xterm/css/xterm.css";
 
@@ -616,6 +616,11 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
 
         // Intercept copy shortcuts while allowing native paste events through.
         term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+          if (isTerminalPasteShortcut(e)) {
+            // Do not preventDefault here; WebView must dispatch paste to the hidden textarea.
+            return false;
+          }
+
           if (e.type === 'keydown' && (e.ctrlKey || e.metaKey) && !e.altKey) {
             // Copy the selection on Ctrl+C; otherwise let the terminal handle SIGINT.
             if (!e.shiftKey && (e.key === 'c' || e.key === 'C')) {

--- a/web/components/panes/TerminalView.tsx
+++ b/web/components/panes/TerminalView.tsx
@@ -15,6 +15,8 @@ import { replayAttachedSession } from "./terminalReplay";
 import { formatTerminalInitError } from "./terminalInitError";
 import { buildCursorPositionReport } from "./terminalCpr";
 import { isTerminalPasteShortcut, resolveTerminalPastePayload } from "./terminalClipboard";
+import { applyTerminalDisplayOptions, resolveTerminalDisplayOptions } from "./terminalOptions";
+import { resolveTerminalWheelMode } from "./terminalWheel";
 import { createTerminalWriteFlowControl } from "./terminalWriteFlowControl";
 import "@xterm/xterm/css/xterm.css";
 
@@ -136,6 +138,7 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     const debugInstanceIdRef = useRef(`term-${Math.random().toString(36).slice(2, 8)}`);
     const trackedBufferTypeRef = useRef<"unknown" | "normal" | "alternate">("unknown");
     const lastWheelDecisionRef = useRef<string | null>(null);
+    const terminalSettings = useSettingsStore((s) => s.settings?.terminal);
 
     const debugLog = useCallback((event: string, payload: Record<string, unknown> = {}) => {
       if (!TERMINAL_DEBUG) return;
@@ -271,7 +274,7 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
 
       // Remove the wheel handler before disposing xterm.
       if (wheelHandlerRef.current && terminalInstanceRef.current?.element) {
-        terminalInstanceRef.current.element.removeEventListener('wheel', wheelHandlerRef.current);
+        terminalInstanceRef.current.element.removeEventListener('wheel', wheelHandlerRef.current, true);
         wheelHandlerRef.current = null;
       }
       if (pasteHandlerRef.current && terminalInstanceRef.current?.textarea) {
@@ -460,16 +463,13 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
 
         if (!isMounted || !terminalRef.current) return;
 
-        const termSettings = useSettingsStore.getState().settings?.terminal;
-        const scrollback = termSettings?.scrollback ?? 1000;
-        const fontFamily = termSettings?.fontFamily || 'Consolas, "Courier New", "Microsoft YaHei Mono", "Noto Sans Mono CJK SC", "PingFang SC", monospace';
+        const displayOptions = resolveTerminalDisplayOptions(
+          useSettingsStore.getState().settings?.terminal
+        );
 
         const term = new Terminal({
           allowProposedApi: true,
-          cursorBlink: true,
-          fontSize: 14,
-          scrollback,
-          fontFamily,
+          ...displayOptions,
           ...(navigator.platform.startsWith('Win') && buildNumber && buildNumber > 0 && {
             windowsPty: {
               backend: 'conpty' as const,
@@ -511,8 +511,11 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         });
         trackedBufferTypeRef.current = term.buffer.active.type;
         debugLog("xterm.ready", {
-          scrollback,
-          fontFamily,
+          fontSize: displayOptions.fontSize,
+          fontFamily: displayOptions.fontFamily,
+          cursorStyle: displayOptions.cursorStyle,
+          cursorBlink: displayOptions.cursorBlink,
+          scrollback: displayOptions.scrollback,
           initialBuffer: term.buffer.active.type,
           writeFlowControl: IS_WINDOWS ? "enabled" : "disabled",
         });
@@ -698,19 +701,37 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         });
         observer.observe(terminalRef.current);
 
-        // Convert wheel events into arrow keys while the alternate buffer is active.
+        // Let normal scrollback use browser scrolling before xterm mouse reporting can cancel it.
+        // Alternate-buffer apps still receive arrow keys for wheel navigation.
         const wheelHandler = (e: WheelEvent) => {
-          const bufferType = term.buffer.active.type;
-          const decision = bufferType === "alternate" ? "alternate-handle" : "normal-bypass";
+          const buffer = term.buffer.active;
+          const bufferType = buffer.type;
+          const wheelMode = resolveTerminalWheelMode({
+            bufferType,
+            baseY: buffer.baseY,
+          });
+          const decision =
+            wheelMode === "browser-history"
+              ? "normal-browser-history"
+              : wheelMode === "alternate-app"
+                ? "alternate-handle"
+                : "normal-bypass";
           if (lastWheelDecisionRef.current !== decision) {
             lastWheelDecisionRef.current = decision;
             debugLog("wheel.mode", {
               bufferType,
+              baseY: buffer.baseY,
               decision,
               deltaMode: e.deltaMode,
             });
           }
-          if (bufferType !== 'alternate') return;
+
+          if (wheelMode === "browser-history") {
+            e.stopImmediatePropagation();
+            return;
+          }
+
+          if (wheelMode !== "alternate-app") return;
           e.preventDefault();
           e.stopPropagation();
           const lines = Math.max(1, Math.round(Math.abs(e.deltaY) / 40));
@@ -719,7 +740,7 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
             terminalService.write(currentSessionIdRef.current, arrow.repeat(lines));
           }
         };
-        term.element?.addEventListener('wheel', wheelHandler, { passive: false });
+        term.element?.addEventListener('wheel', wheelHandler, { passive: false, capture: true });
         wheelHandlerRef.current = wheelHandler;
 
         terminalInstanceRef.current = term;
@@ -958,6 +979,51 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         window.removeEventListener("focus", handleWindowFocus);
       };
     }, [scheduleTextureAtlasRefresh]);
+
+    useEffect(() => {
+      const term = terminalInstanceRef.current;
+      if (!term) return;
+
+      const displayOptions = resolveTerminalDisplayOptions(terminalSettings);
+      const changed = applyTerminalDisplayOptions(term, displayOptions);
+      if (!changed) return;
+
+      debugLog("settings.terminal.applied", {
+        fontSize: displayOptions.fontSize,
+        fontFamily: displayOptions.fontFamily,
+        cursorStyle: displayOptions.cursorStyle,
+        cursorBlink: displayOptions.cursorBlink,
+        scrollback: displayOptions.scrollback,
+      });
+
+      let cancelled = false;
+      const rafId = requestAnimationFrame(() => {
+        if (cancelled || isUnmountedRef.current) return;
+        const currentTerm = terminalInstanceRef.current;
+        const fitAddon = fitAddonRef.current;
+        if (!currentTerm || !fitAddon) return;
+
+        fitAddon.fit();
+        currentTerm.refresh(0, Math.max(0, currentTerm.rows - 1));
+        scheduleTextureAtlasRefresh("terminal-settings");
+
+        const { cols, rows } = currentTerm;
+        if (lastSizeRef.current?.cols === cols && lastSizeRef.current?.rows === rows) return;
+        lastSizeRef.current = { cols, rows };
+        if (currentSessionIdRef.current) {
+          terminalService.resize({
+            sessionId: currentSessionIdRef.current,
+            cols,
+            rows,
+          });
+        }
+      });
+
+      return () => {
+        cancelled = true;
+        cancelAnimationFrame(rafId);
+      };
+    }, [debugLog, scheduleTextureAtlasRefresh, terminalSettings]);
 
     // Refit on activation and create deferred PTYs for restored tabs.
     useEffect(() => {

--- a/web/components/panes/terminalClipboard.test.ts
+++ b/web/components/panes/terminalClipboard.test.ts
@@ -17,6 +17,7 @@ vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
 
 import {
   clipboardHasImage,
+  isTerminalPasteShortcut,
   resolveTerminalPastePayload,
 } from "./terminalClipboard";
 
@@ -31,6 +32,26 @@ function createClipboardData({
     items,
     getData: vi.fn((type: string) => (type === "text/plain" ? text : "")),
   } as unknown as DataTransfer;
+}
+
+function createKeyboardEvent(
+  key: string,
+  options: {
+    ctrlKey?: boolean;
+    shiftKey?: boolean;
+    altKey?: boolean;
+    metaKey?: boolean;
+  } = {}
+): KeyboardEvent {
+  return new KeyboardEvent("keydown", {
+    key,
+    ctrlKey: options.ctrlKey ?? false,
+    shiftKey: options.shiftKey ?? false,
+    altKey: options.altKey ?? false,
+    metaKey: options.metaKey ?? false,
+    bubbles: true,
+    cancelable: true,
+  });
 }
 
 describe("terminalClipboard", () => {
@@ -67,6 +88,14 @@ describe("terminalClipboard", () => {
         })
       )
     ).toBe(false);
+  });
+
+  it("identifies native paste shortcuts that should bypass xterm key handling", () => {
+    expect(isTerminalPasteShortcut(createKeyboardEvent("v", { ctrlKey: true }))).toBe(true);
+    expect(isTerminalPasteShortcut(createKeyboardEvent("V", { ctrlKey: true, shiftKey: true }))).toBe(true);
+    expect(isTerminalPasteShortcut(createKeyboardEvent("v", { metaKey: true }))).toBe(true);
+    expect(isTerminalPasteShortcut(createKeyboardEvent("v", { ctrlKey: true, altKey: true }))).toBe(false);
+    expect(isTerminalPasteShortcut(createKeyboardEvent("c", { ctrlKey: true }))).toBe(false);
   });
 
   it("prefers clipboard images and returns the saved file path", async () => {

--- a/web/components/panes/terminalClipboard.ts
+++ b/web/components/panes/terminalClipboard.ts
@@ -19,6 +19,13 @@ export function clipboardHasImage(clipboardData?: DataTransfer | null): boolean 
   );
 }
 
+export function isTerminalPasteShortcut(e: KeyboardEvent): boolean {
+  if (e.type !== "keydown") return false;
+  if (e.altKey) return false;
+  if (!e.ctrlKey && !e.metaKey) return false;
+  return e.key.toLowerCase() === "v";
+}
+
 export async function readClipboardText(textHint?: string | null): Promise<string> {
   if (textHint) return textHint;
 

--- a/web/components/panes/terminalOptions.test.ts
+++ b/web/components/panes/terminalOptions.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { TerminalSettings } from "@/types";
+import {
+  DEFAULT_TERMINAL_DISPLAY_OPTIONS,
+  applyTerminalDisplayOptions,
+  resolveTerminalDisplayOptions,
+} from "./terminalOptions";
+
+function createTerminalSettings(overrides: Partial<TerminalSettings> = {}): TerminalSettings {
+  return {
+    fontSize: 14,
+    fontFamily: "monospace",
+    cursorStyle: "block",
+    cursorBlink: true,
+    scrollback: 1000,
+    shell: null,
+    disableConptySanitize: null,
+    ...overrides,
+  };
+}
+
+describe("terminalOptions", () => {
+  it("uses terminal display settings for xterm options", () => {
+    expect(
+      resolveTerminalDisplayOptions(
+        createTerminalSettings({
+          fontSize: 18,
+          fontFamily: "JetBrains Mono",
+          cursorStyle: "bar",
+          cursorBlink: false,
+          scrollback: 5000,
+        })
+      )
+    ).toEqual({
+      fontSize: 18,
+      fontFamily: "JetBrains Mono",
+      cursorStyle: "bar",
+      cursorBlink: false,
+      scrollback: 5000,
+    });
+  });
+
+  it("falls back to safe defaults for invalid terminal display settings", () => {
+    expect(
+      resolveTerminalDisplayOptions({
+        fontSize: 0,
+        fontFamily: "",
+        cursorStyle: "invalid",
+        cursorBlink: true,
+        scrollback: 0,
+      } as TerminalSettings)
+    ).toEqual(DEFAULT_TERMINAL_DISPLAY_OPTIONS);
+  });
+
+  it("applies changed display options to an existing terminal", () => {
+    const terminal = {
+      options: {
+        fontSize: 14,
+        fontFamily: "monospace",
+        cursorStyle: "block",
+        cursorBlink: true,
+        scrollback: 1000,
+      },
+    };
+
+    const changed = applyTerminalDisplayOptions(
+      terminal,
+      resolveTerminalDisplayOptions(
+        createTerminalSettings({
+          fontSize: 16,
+          fontFamily: "Cascadia Code",
+          cursorStyle: "underline",
+          cursorBlink: false,
+          scrollback: 2000,
+        })
+      )
+    );
+
+    expect(changed).toBe(true);
+    expect(terminal.options).toEqual({
+      fontSize: 16,
+      fontFamily: "Cascadia Code",
+      cursorStyle: "underline",
+      cursorBlink: false,
+      scrollback: 2000,
+    });
+  });
+});

--- a/web/components/panes/terminalOptions.ts
+++ b/web/components/panes/terminalOptions.ts
@@ -1,0 +1,82 @@
+import type { TerminalSettings } from "@/types";
+
+export type TerminalCursorStyle = "block" | "underline" | "bar";
+
+export interface TerminalDisplayOptions {
+  fontSize: number;
+  fontFamily: string;
+  cursorStyle: TerminalCursorStyle;
+  cursorBlink: boolean;
+  scrollback: number;
+}
+
+export interface TerminalOptionsTarget {
+  options: {
+    fontSize?: number;
+    fontFamily?: string;
+    cursorStyle?: string;
+    cursorBlink?: boolean;
+    scrollback?: number;
+  };
+}
+
+export const DEFAULT_TERMINAL_DISPLAY_OPTIONS: TerminalDisplayOptions = {
+  fontSize: 14,
+  fontFamily:
+    'Consolas, "Courier New", "Microsoft YaHei Mono", "Noto Sans Mono CJK SC", "PingFang SC", monospace',
+  cursorStyle: "block",
+  cursorBlink: true,
+  scrollback: 1000,
+};
+
+const CURSOR_STYLES = new Set<TerminalCursorStyle>(["block", "underline", "bar"]);
+
+function positiveIntegerOrDefault(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : fallback;
+}
+
+function cursorStyleOrDefault(value: unknown): TerminalCursorStyle {
+  return CURSOR_STYLES.has(value as TerminalCursorStyle)
+    ? (value as TerminalCursorStyle)
+    : DEFAULT_TERMINAL_DISPLAY_OPTIONS.cursorStyle;
+}
+
+export function resolveTerminalDisplayOptions(
+  settings?: Partial<TerminalSettings> | null
+): TerminalDisplayOptions {
+  return {
+    fontSize: positiveIntegerOrDefault(
+      settings?.fontSize,
+      DEFAULT_TERMINAL_DISPLAY_OPTIONS.fontSize
+    ),
+    fontFamily:
+      settings?.fontFamily?.trim() ||
+      DEFAULT_TERMINAL_DISPLAY_OPTIONS.fontFamily,
+    cursorStyle: cursorStyleOrDefault(settings?.cursorStyle),
+    cursorBlink:
+      typeof settings?.cursorBlink === "boolean"
+        ? settings.cursorBlink
+        : DEFAULT_TERMINAL_DISPLAY_OPTIONS.cursorBlink,
+    scrollback: positiveIntegerOrDefault(
+      settings?.scrollback,
+      DEFAULT_TERMINAL_DISPLAY_OPTIONS.scrollback
+    ),
+  };
+}
+
+export function applyTerminalDisplayOptions(
+  terminal: TerminalOptionsTarget,
+  options: TerminalDisplayOptions
+): boolean {
+  let changed = false;
+
+  for (const key of Object.keys(options) as Array<keyof TerminalDisplayOptions>) {
+    if (terminal.options[key] === options[key]) continue;
+    terminal.options[key] = options[key] as never;
+    changed = true;
+  }
+
+  return changed;
+}

--- a/web/components/panes/terminalWheel.test.ts
+++ b/web/components/panes/terminalWheel.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { resolveTerminalWheelMode } from "./terminalWheel";
+
+describe("terminalWheel", () => {
+  it("lets the browser scroll normal-buffer history when scrollback exists", () => {
+    expect(
+      resolveTerminalWheelMode({
+        bufferType: "normal",
+        baseY: 20,
+      })
+    ).toBe("browser-history");
+  });
+
+  it("keeps alternate-buffer wheel events routed to the terminal app", () => {
+    expect(
+      resolveTerminalWheelMode({
+        bufferType: "alternate",
+        baseY: 0,
+      })
+    ).toBe("alternate-app");
+  });
+
+  it("uses xterm defaults when the normal buffer has no scrollback", () => {
+    expect(
+      resolveTerminalWheelMode({
+        bufferType: "normal",
+        baseY: 0,
+      })
+    ).toBe("xterm-default");
+  });
+});

--- a/web/components/panes/terminalWheel.ts
+++ b/web/components/panes/terminalWheel.ts
@@ -1,0 +1,15 @@
+export type TerminalWheelMode =
+  | "browser-history"
+  | "alternate-app"
+  | "xterm-default";
+
+export interface TerminalWheelState {
+  bufferType: "normal" | "alternate" | "unknown";
+  baseY: number;
+}
+
+export function resolveTerminalWheelMode(state: TerminalWheelState): TerminalWheelMode {
+  if (state.bufferType === "alternate") return "alternate-app";
+  if (state.bufferType === "normal" && state.baseY > 0) return "browser-history";
+  return "xterm-default";
+}


### PR DESCRIPTION
## Summary
- 修复终端 `Ctrl+V` / `Cmd+V` / `Ctrl+Shift+V` 粘贴快捷键被 xterm 键盘处理吞掉的问题，让 WebView 正常派发原生 `paste` 事件。
- 保留现有右键粘贴、文本粘贴和剪贴板图片粘贴链路，避免影响 `Ctrl+C` 复制选区 / SIGINT 行为。
- 让终端设置真正应用到 xterm：`fontSize`、`fontFamily`、`cursorStyle`、`cursorBlink`、`scrollback`。
- 设置保存后同步更新已打开的终端，并重新 `fit()`、刷新视图、同步 PTY 尺寸。
- 对无效的 `fontSize` / `scrollback` 做安全回退，避免回滚行数变成 `0` 后只能显示一屏。
- 调整 normal buffer 滚轮处理：有 scrollback 历史时优先交给浏览器滚动历史，alternate buffer 仍保留 TUI 应用滚轮导航。
- 增加终端粘贴、终端显示设置、滚轮模式和写入流控相关单元测试。

## Test Plan
- `npx.cmd tsc --noEmit`
- `npm.cmd run test:run -- web/components/panes/terminalOptions.test.ts web/components/panes/terminalWheel.test.ts web/components/panes/terminalClipboard.test.ts web/components/panes/terminalWriteFlowControl.test.ts`
- `npm.cmd run test:run -- web/components/panes/terminalClipboard.test.ts web/stores/useShortcutsStore.test.ts`