### PR TITLE
fix: dedupe Linux IME input in terminal

### DIFF
--- a/web/components/panes/TerminalView.tsx
+++ b/web/components/panes/TerminalView.tsx
@@ -33,6 +33,7 @@ import {
 } from "./terminalBufferMode";
 import { formatTerminalFilePaths, resolveTerminalPastePayload } from "./terminalClipboard";
 import { isDropInsideTerminalHost } from "./terminalDrop";
+import { attachTerminalImeGuard } from "./terminalImeGuard";
 import { attachTerminalInputTrace } from "./terminalInputTrace";
 import { isTerminalPasteShortcut } from "./terminalKeyboard";
 import { createTerminalWriteFlowControl } from "./terminalWriteFlowControl";
@@ -66,6 +67,7 @@ import type { CliTool, CreateSessionRequest, SshConnectionInfo, TerminalRenderer
 const TERMINAL_DEBUG = import.meta.env.DEV;
 const IS_WINDOWS = typeof navigator !== "undefined" && navigator.platform.startsWith("Win");
 const IS_MAC = typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+const IS_LINUX = typeof navigator !== "undefined" && /Linux/.test(navigator.platform);
 const DEFAULT_TERMINAL_SCROLLBACK = 20_000;
 
 function resolveCliTool(cliTool?: CliTool, launchClaude?: boolean): string {
@@ -167,6 +169,7 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     const wheelHandlerRef = useRef<((e: WheelEvent) => void) | null>(null);
     const pasteHandlerRef = useRef<((e: ClipboardEvent) => void) | null>(null);
     const dragDropUnlistenRef = useRef<(() => void) | null>(null);
+    const imeGuardRef = useRef<ReturnType<typeof attachTerminalImeGuard> | null>(null);
     const inputTraceRef = useRef<ReturnType<typeof attachTerminalInputTrace> | null>(null);
     const parserDisposableRefs = useRef<IDisposable[]>([]);
     const writeFlowControlRef = useRef<ReturnType<typeof createTerminalWriteFlowControl> | null>(null);
@@ -390,6 +393,8 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       }
       inputTraceRef.current?.dispose();
       inputTraceRef.current = null;
+      imeGuardRef.current?.dispose();
+      imeGuardRef.current = null;
 
       // Remove the wheel handler before disposing xterm.
       if (wheelHandlerRef.current && terminalInstanceRef.current?.element) {
@@ -811,6 +816,11 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
 
           textarea.addEventListener('paste', pasteHandler, true);
           pasteHandlerRef.current = pasteHandler;
+          imeGuardRef.current = attachTerminalImeGuard({
+            textarea,
+            enabled: IS_LINUX,
+            logger: debugLog,
+          });
           inputTraceRef.current = attachTerminalInputTrace({
             textarea,
             isDev: TERMINAL_DEBUG,
@@ -892,16 +902,18 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         // Forward terminal input, with Enter-to-reconnect handling for SSH disconnects.
         const onDataDisposable = term.onData((data) => {
           inputTraceRef.current?.onData(data);
+          const filteredData = imeGuardRef.current?.filterData(data) ?? data;
+          if (!filteredData) return;
           // Only Enter should trigger reconnect while disconnected.
           if (isDisconnectedRef.current) {
-            if (!isReconnectingRef.current && (data === "\r" || data === "\n")) {
+            if (!isReconnectingRef.current && (filteredData === "\r" || filteredData === "\n")) {
               doReconnect();
             }
             return;
           }
           const sessionId = currentSessionIdRef.current;
           if (sessionId) {
-            terminalService.write(sessionId, data);
+            terminalService.write(sessionId, filteredData);
           }
         });
         onDataDisposableRef.current = onDataDisposable;

--- a/web/components/panes/terminalImeGuard.test.ts
+++ b/web/components/panes/terminalImeGuard.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  attachTerminalImeGuard,
+  createTerminalImeGuard,
+} from "./terminalImeGuard";
+
+function clock(start = 0) {
+  let value = start;
+  return {
+    now: () => value,
+    advance: (ms: number) => {
+      value += ms;
+    },
+  };
+}
+
+function inputEvent(data: string, inputType = "insertText", isComposing = false) {
+  return {
+    data,
+    inputType,
+    isComposing,
+  };
+}
+
+describe("terminalImeGuard", () => {
+  it("passes data through when disabled", () => {
+    const guard = createTerminalImeGuard({ enabled: false });
+
+    guard.compositionStart();
+    guard.input(inputEvent("你", "insertText", true));
+    guard.compositionEnd({ data: "你" });
+
+    expect(guard.filterData("你")).toBe("你");
+    expect(guard.filterData("你")).toBe("你");
+  });
+
+  it("drops delayed compositionend data after input already forwarded it", () => {
+    const logger = vi.fn();
+    const time = clock();
+    const guard = createTerminalImeGuard({
+      enabled: true,
+      now: time.now,
+      logger,
+    });
+
+    guard.compositionStart();
+    guard.input(inputEvent("你", "insertText", true));
+
+    expect(guard.filterData("你")).toBe("你");
+
+    guard.compositionEnd({ data: "你" });
+
+    expect(guard.filterData("你")).toBe("");
+    expect(logger).toHaveBeenCalledWith("ime.duplicate.drop", {
+      source: "compositionend",
+      length: 1,
+    });
+  });
+
+  it("drops duplicate data when xterm onData fires before the input listener records it", () => {
+    const guard = createTerminalImeGuard({ enabled: true });
+
+    guard.compositionStart();
+
+    expect(guard.filterData("你")).toBe("你");
+
+    guard.input(inputEvent("你", "insertText", true));
+    guard.compositionEnd({ data: "你" });
+
+    expect(guard.filterData("你")).toBe("");
+  });
+
+  it("drops input data after compositionend already forwarded it", () => {
+    const guard = createTerminalImeGuard({ enabled: true });
+
+    guard.compositionStart();
+    guard.compositionEnd({ data: "中" });
+
+    expect(guard.filterData("中")).toBe("中");
+
+    guard.input(inputEvent("中", "insertText", false));
+
+    expect(guard.filterData("中")).toBe("");
+  });
+
+  it("trims duplicate prefix while preserving new suffix data", () => {
+    const logger = vi.fn();
+    const guard = createTerminalImeGuard({ enabled: true, logger });
+
+    guard.compositionStart();
+    guard.input(inputEvent("你", "insertText", true));
+
+    expect(guard.filterData("你")).toBe("你");
+
+    guard.compositionEnd({ data: "你" });
+
+    expect(guard.filterData("你2")).toBe("2");
+    expect(logger).toHaveBeenCalledWith("ime.duplicate.trim", {
+      source: "compositionend",
+      originalLength: 2,
+      duplicateLength: 1,
+      suffixLength: 1,
+    });
+  });
+
+  it("drops combined duplicate data when suffix was already sent separately", () => {
+    const guard = createTerminalImeGuard({ enabled: true });
+
+    guard.compositionStart();
+    guard.input(inputEvent("你", "insertText", true));
+
+    expect(guard.filterData("你")).toBe("你");
+
+    guard.compositionEnd({ data: "你" });
+
+    expect(guard.filterData("2")).toBe("2");
+    expect(guard.filterData("你2")).toBe("");
+  });
+
+  it("trims stale cumulative textarea payloads across composition commits", () => {
+    const logger = vi.fn();
+    const guard = createTerminalImeGuard({ enabled: true, logger });
+
+    guard.compositionStart();
+    expect(guard.filterData("你好")).toBe("你好");
+    guard.input(inputEvent("你好", "insertText", true));
+    guard.compositionEnd({ data: "你好" });
+    expect(guard.filterData("你好")).toBe("");
+
+    guard.compositionStart();
+    expect(guard.filterData("你好你好")).toBe("你好");
+
+    expect(logger).toHaveBeenCalledWith("ime.cumulative.trim", {
+      originalLength: 4,
+      prefixLength: 2,
+      suffixLength: 2,
+    });
+  });
+
+  it("drops repeated cumulative textarea payloads after the suffix was forwarded", () => {
+    const logger = vi.fn();
+    const guard = createTerminalImeGuard({ enabled: true, logger });
+
+    guard.compositionStart();
+    expect(guard.filterData("你好")).toBe("你好");
+    guard.compositionEnd({ data: "你好" });
+    expect(guard.filterData("你好")).toBe("");
+
+    guard.compositionStart();
+    guard.beforeInput(inputEvent("你好", "insertText", true));
+    expect(guard.filterData("你好你好")).toBe("你好");
+    guard.compositionEnd({ data: "你好" });
+
+    expect(guard.filterData("你好你好")).toBe("");
+    expect(logger).toHaveBeenCalledWith("ime.cumulative.drop", {
+      source: "compositionend",
+      originalLength: 4,
+      prefixLength: 2,
+      suffixLength: 2,
+    });
+  });
+
+  it("trims cumulative payloads to the current composition candidate", () => {
+    const guard = createTerminalImeGuard({ enabled: true });
+
+    guard.compositionStart();
+    expect(guard.filterData("你好")).toBe("你好");
+    guard.compositionEnd({ data: "你好" });
+    expect(guard.filterData("你好")).toBe("");
+
+    guard.compositionStart();
+    guard.beforeInput(inputEvent("世界", "insertText", true));
+
+    expect(guard.filterData("你好世界")).toBe("世界");
+  });
+
+  it("keeps printable ascii history when trimming cumulative IME data", () => {
+    const guard = createTerminalImeGuard({ enabled: true });
+
+    guard.compositionStart();
+    expect(guard.filterData("你好")).toBe("你好");
+    guard.compositionEnd({ data: "你好" });
+    expect(guard.filterData("你好")).toBe("");
+    expect(guard.filterData(" ")).toBe(" ");
+
+    guard.compositionStart();
+
+    expect(guard.filterData("你好 你好")).toBe("你好");
+  });
+
+  it("restores the full IME candidate when xterm emits only its suffix", () => {
+    const logger = vi.fn();
+    const guard = createTerminalImeGuard({ enabled: true, logger });
+
+    guard.compositionStart();
+    guard.beforeInput(inputEvent("你好", "insertText", true));
+
+    expect(guard.filterData("好")).toBe("你好");
+    expect(logger).toHaveBeenCalledWith("ime.suffix.restore", {
+      source: "beforeinput",
+      dataLength: 1,
+      candidateLength: 2,
+    });
+  });
+
+  it("drops a repeated candidate suffix after the full candidate was forwarded", () => {
+    const logger = vi.fn();
+    const guard = createTerminalImeGuard({ enabled: true, logger });
+
+    guard.compositionStart();
+    guard.input(inputEvent("你好", "insertText", true));
+    expect(guard.filterData("你好")).toBe("你好");
+    guard.compositionEnd({ data: "你好" });
+
+    expect(guard.filterData("好")).toBe("");
+    expect(logger).toHaveBeenCalledWith("ime.suffix.drop", {
+      source: "compositionend",
+      dataLength: 1,
+      candidateLength: 2,
+    });
+  });
+
+  it("keeps a separated repeated IME word intact after a space", () => {
+    const guard = createTerminalImeGuard({ enabled: true });
+
+    guard.compositionStart();
+    guard.input(inputEvent("你好", "insertText", true));
+    expect(guard.filterData("你好")).toBe("你好");
+    guard.compositionEnd({ data: "你好" });
+    expect(guard.filterData("你好")).toBe("");
+    expect(guard.filterData(" ")).toBe(" ");
+
+    guard.compositionStart();
+    guard.beforeInput(inputEvent("你好", "insertText", true));
+    expect(guard.filterData("好")).toBe("你好");
+    guard.compositionEnd({ data: "你好" });
+    expect(guard.filterData("好")).toBe("");
+  });
+
+  it("expires stale duplicate candidates", () => {
+    const time = clock();
+    const guard = createTerminalImeGuard({ enabled: true, now: time.now });
+
+    guard.compositionStart();
+    guard.input(inputEvent("好", "insertText", true));
+
+    expect(guard.filterData("好")).toBe("好");
+
+    guard.compositionEnd({ data: "好" });
+    time.advance(300);
+
+    expect(guard.filterData("好")).toBe("好");
+  });
+
+  it("ignores normal ascii input outside composition", () => {
+    const guard = createTerminalImeGuard({ enabled: true });
+
+    guard.input(inputEvent("a", "insertText", false));
+
+    expect(guard.filterData("a")).toBe("a");
+    expect(guard.filterData("a")).toBe("a");
+  });
+
+  it("clears the textarea after xterm has handled compositionend", () => {
+    vi.useFakeTimers();
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = "你好";
+      const logger = vi.fn();
+      const guard = attachTerminalImeGuard({
+        textarea,
+        enabled: true,
+        logger,
+      });
+
+      textarea.dispatchEvent(new CompositionEvent("compositionend", {
+        data: "你好",
+        bubbles: true,
+      }));
+
+      expect(textarea.value).toBe("你好");
+
+      vi.runAllTimers();
+
+      expect(textarea.value).toBe("");
+      expect(logger).toHaveBeenCalledWith("ime.textarea.clear", {
+        valueLength: 2,
+      });
+
+      guard.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not treat ascii typed after composition as duplicate IME data", () => {
+    const guard = createTerminalImeGuard({ enabled: true });
+
+    guard.compositionStart();
+    guard.input(inputEvent("你", "insertText", true));
+    expect(guard.filterData("你")).toBe("你");
+    guard.compositionEnd({ data: "你" });
+    expect(guard.filterData("你")).toBe("");
+
+    guard.input(inputEvent("a", "insertText", false));
+
+    expect(guard.filterData("a")).toBe("a");
+    expect(guard.filterData("a")).toBe("a");
+  });
+
+  it("attaches DOM listeners and filters emitted data", () => {
+    const textarea = document.createElement("textarea");
+    const guard = attachTerminalImeGuard({
+      textarea,
+      enabled: true,
+    });
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart", {
+      bubbles: true,
+    }));
+    textarea.dispatchEvent(new InputEvent("input", {
+      inputType: "insertText",
+      data: "测",
+      isComposing: true,
+      bubbles: true,
+    }));
+
+    expect(guard.filterData("测")).toBe("测");
+
+    textarea.dispatchEvent(new CompositionEvent("compositionend", {
+      data: "测",
+      bubbles: true,
+    }));
+
+    expect(guard.filterData("测")).toBe("");
+
+    guard.dispose();
+  });
+});

--- a/web/components/panes/terminalImeGuard.ts
+++ b/web/components/panes/terminalImeGuard.ts
@@ -1,0 +1,431 @@
+type ImeLogger = (event: string, payload?: Record<string, unknown>) => void;
+
+interface PendingCommit {
+  text: string;
+  forwarded: boolean;
+  expiresAt: number;
+  serial: number;
+  order: number;
+  source: string;
+}
+
+interface RecentData {
+  text: string;
+  expiresAt: number;
+  serial: number;
+}
+
+interface ImeInputLike {
+  data: string | null;
+  inputType: string;
+  isComposing: boolean;
+}
+
+interface ImeCompositionLike {
+  data: string;
+}
+
+export interface TerminalImeGuard {
+  beforeInput: (event: ImeInputLike) => void;
+  input: (event: ImeInputLike) => void;
+  compositionStart: () => void;
+  compositionEnd: (event: ImeCompositionLike) => void;
+  filterData: (data: string) => string;
+}
+
+export interface TerminalImeGuardController {
+  dispose: () => void;
+  filterData: (data: string) => string;
+}
+
+interface TerminalImeGuardOptions {
+  enabled: boolean;
+  now?: () => number;
+  logger?: ImeLogger;
+}
+
+interface AttachTerminalImeGuardOptions extends TerminalImeGuardOptions {
+  textarea?: HTMLTextAreaElement | null;
+}
+
+const DUPLICATE_WINDOW_MS = 250;
+const RECENT_DATA_WINDOW_MS = 250;
+const FORWARDED_TEXT_HISTORY_LIMIT = 512;
+
+function getNow(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function isTrackableInput(event: ImeInputLike): boolean {
+  return (
+    event.inputType === "insertText" ||
+    event.inputType === "insertCompositionText"
+  );
+}
+
+function hasNonAsciiText(text: string): boolean {
+  return /[^\x00-\x7F]/.test(text);
+}
+
+function isPlainPrintableText(text: string): boolean {
+  return text.length > 0 && !/[\x00-\x1F\x7F]/.test(text);
+}
+
+function limitTextHistory(text: string): string {
+  return Array.from(text).slice(-FORWARDED_TEXT_HISTORY_LIMIT).join("");
+}
+
+export function createTerminalImeGuard({
+  enabled,
+  now = getNow,
+  logger,
+}: TerminalImeGuardOptions): TerminalImeGuard {
+  let compositionSerial = 0;
+  let isComposing = false;
+  let recentCompositionUntil = 0;
+  let nextOrder = 0;
+  let pendingCommits: PendingCommit[] = [];
+  let recentData: RecentData[] = [];
+  let forwardedTextHistory = "";
+
+  const purge = (timestamp: number) => {
+    pendingCommits = pendingCommits.filter(
+      (candidate) =>
+        candidate.serial === compositionSerial &&
+        candidate.expiresAt >= timestamp,
+    );
+    recentData = recentData.filter(
+      (item) =>
+        item.serial === compositionSerial &&
+        item.expiresAt >= timestamp,
+    );
+  };
+
+  const hasRecentForwardedText = (text: string, timestamp: number) => {
+    purge(timestamp);
+    const combined = recentData.map((item) => item.text).join("");
+    return (
+      recentData.some((item) => item.text === text || item.text.startsWith(text)) ||
+      combined.endsWith(text)
+    );
+  };
+
+  const markPendingFromRecentData = (timestamp: number) => {
+    for (const candidate of pendingCommits) {
+      if (!candidate.forwarded && hasRecentForwardedText(candidate.text, timestamp)) {
+        candidate.forwarded = true;
+      }
+    }
+  };
+
+  const rememberData = (data: string, timestamp: number) => {
+    if (!data) return;
+    recentData.push({
+      text: data,
+      expiresAt: timestamp + RECENT_DATA_WINDOW_MS,
+      serial: compositionSerial,
+    });
+    markPendingFromRecentData(timestamp);
+  };
+
+  const rememberForwardedText = (data: string) => {
+    if (!isPlainPrintableText(data)) return;
+    forwardedTextHistory = limitTextHistory(`${forwardedTextHistory}${data}`);
+  };
+
+  const findCumulativeSuffix = (data: string) => {
+    if (!data || !forwardedTextHistory) return null;
+
+    const maxPrefixLength = Math.min(data.length - 1, forwardedTextHistory.length);
+    for (let prefixLength = maxPrefixLength; prefixLength > 0; prefixLength -= 1) {
+      const prefix = data.slice(0, prefixLength);
+      if (!forwardedTextHistory.endsWith(prefix)) continue;
+
+      const suffix = data.slice(prefixLength);
+      if (suffix && hasNonAsciiText(suffix)) {
+        return {
+          prefixLength,
+          suffix,
+        };
+      }
+    }
+
+    return null;
+  };
+
+  const trimCumulativeData = (data: string) => {
+    if (!isComposing && now() > recentCompositionUntil && pendingCommits.length === 0) {
+      return null;
+    }
+    return findCumulativeSuffix(data);
+  };
+
+  const findCandidateSuffix = (data: string) => {
+    if (!data) return null;
+    return pendingCommits
+      .filter((item) => item.text !== data && item.text.endsWith(data))
+      .sort((a, b) => b.order - a.order)[0] ?? null;
+  };
+
+  const recordCommitCandidate = (text: string | null, source: string) => {
+    if (!enabled || !text) return;
+
+    const timestamp = now();
+    purge(timestamp);
+    const forwarded = hasRecentForwardedText(text, timestamp);
+    const existing = pendingCommits.find(
+      (candidate) =>
+        candidate.serial === compositionSerial &&
+        candidate.text === text,
+    );
+
+    if (existing) {
+      existing.forwarded = existing.forwarded || forwarded;
+      existing.expiresAt = timestamp + DUPLICATE_WINDOW_MS;
+      existing.order = ++nextOrder;
+      existing.source = source;
+      return;
+    }
+
+    pendingCommits.unshift({
+      text,
+      forwarded,
+      expiresAt: timestamp + DUPLICATE_WINDOW_MS,
+      serial: compositionSerial,
+      order: ++nextOrder,
+      source,
+    });
+  };
+
+  const trackInputCandidate = (event: ImeInputLike, source: string) => {
+    if (!enabled || !event.data || !isTrackableInput(event)) return;
+
+    const timestamp = now();
+    if (
+      isComposing ||
+      event.isComposing ||
+      (timestamp <= recentCompositionUntil && hasNonAsciiText(event.data)) ||
+      event.inputType === "insertCompositionText"
+    ) {
+      recordCommitCandidate(event.data, source);
+    }
+  };
+
+  return {
+    beforeInput: (event) => trackInputCandidate(event, "beforeinput"),
+    input: (event) => trackInputCandidate(event, "input"),
+    compositionStart: () => {
+      if (!enabled) return;
+      compositionSerial += 1;
+      isComposing = true;
+      recentCompositionUntil = 0;
+      pendingCommits = [];
+      recentData = [];
+    },
+    compositionEnd: (event) => {
+      if (!enabled) return;
+      const timestamp = now();
+      isComposing = false;
+      recentCompositionUntil = timestamp + DUPLICATE_WINDOW_MS;
+      recordCommitCandidate(event.data, "compositionend");
+    },
+    filterData: (data) => {
+      if (!enabled || !data) return data;
+
+      const timestamp = now();
+      purge(timestamp);
+      markPendingFromRecentData(timestamp);
+      const cumulative = trimCumulativeData(data);
+
+      const candidate = pendingCommits
+        .filter((item) => data === item.text || data.startsWith(item.text))
+        .sort((a, b) => b.order - a.order)[0];
+
+      if (!candidate) {
+        const suffixCandidate = findCandidateSuffix(data);
+        if (suffixCandidate) {
+          if (suffixCandidate.forwarded || hasRecentForwardedText(suffixCandidate.text, timestamp)) {
+            pendingCommits = pendingCommits.filter((item) => item !== suffixCandidate);
+            logger?.("ime.suffix.drop", {
+              source: suffixCandidate.source,
+              dataLength: data.length,
+              candidateLength: suffixCandidate.text.length,
+            });
+            return "";
+          }
+
+          suffixCandidate.forwarded = true;
+          suffixCandidate.expiresAt = timestamp + DUPLICATE_WINDOW_MS;
+          logger?.("ime.suffix.restore", {
+            source: suffixCandidate.source,
+            dataLength: data.length,
+            candidateLength: suffixCandidate.text.length,
+          });
+          rememberData(suffixCandidate.text, timestamp);
+          rememberForwardedText(suffixCandidate.text);
+          return suffixCandidate.text;
+        }
+
+        const filteredData = cumulative?.suffix ?? data;
+        if (cumulative) {
+          logger?.("ime.cumulative.trim", {
+            originalLength: data.length,
+            prefixLength: cumulative.prefixLength,
+            suffixLength: filteredData.length,
+          });
+        }
+        rememberData(filteredData, timestamp);
+        rememberForwardedText(filteredData);
+        return filteredData;
+      }
+
+      if (!candidate.forwarded) {
+        candidate.forwarded = true;
+        candidate.expiresAt = timestamp + DUPLICATE_WINDOW_MS;
+        const filteredData = cumulative?.suffix ?? data;
+        if (cumulative) {
+          logger?.("ime.cumulative.trim", {
+            source: candidate.source,
+            originalLength: data.length,
+            prefixLength: cumulative.prefixLength,
+            suffixLength: filteredData.length,
+          });
+        }
+        rememberData(filteredData, timestamp);
+        rememberForwardedText(filteredData);
+        return filteredData;
+      }
+
+      pendingCommits = pendingCommits.filter((item) => item !== candidate);
+      if (cumulative) {
+        if (hasRecentForwardedText(cumulative.suffix, timestamp)) {
+          logger?.("ime.cumulative.drop", {
+            source: candidate.source,
+            originalLength: data.length,
+            prefixLength: cumulative.prefixLength,
+            suffixLength: cumulative.suffix.length,
+          });
+          return "";
+        }
+
+        logger?.("ime.cumulative.trim", {
+          source: candidate.source,
+          originalLength: data.length,
+          prefixLength: cumulative.prefixLength,
+          suffixLength: cumulative.suffix.length,
+        });
+        rememberData(cumulative.suffix, timestamp);
+        rememberForwardedText(cumulative.suffix);
+        return cumulative.suffix;
+      }
+
+      if (hasRecentForwardedText(data, timestamp)) {
+        logger?.("ime.duplicate.drop", {
+          source: candidate.source,
+          length: data.length,
+        });
+        return "";
+      }
+
+      if (data === candidate.text) {
+        logger?.("ime.duplicate.drop", {
+          source: candidate.source,
+          length: data.length,
+        });
+        return "";
+      }
+
+      const suffix = data.slice(candidate.text.length);
+      logger?.("ime.duplicate.trim", {
+        source: candidate.source,
+        originalLength: data.length,
+        duplicateLength: candidate.text.length,
+        suffixLength: suffix.length,
+      });
+      rememberData(suffix, timestamp);
+      rememberForwardedText(suffix);
+      return suffix;
+    },
+  };
+}
+
+function noopController(): TerminalImeGuardController {
+  return {
+    dispose: () => {},
+    filterData: (data) => data,
+  };
+}
+
+export function attachTerminalImeGuard({
+  textarea,
+  enabled,
+  now,
+  logger,
+}: AttachTerminalImeGuardOptions): TerminalImeGuardController {
+  if (!enabled || !textarea) return noopController();
+
+  const guard = createTerminalImeGuard({ enabled, now, logger });
+  const cleanups: Array<() => void> = [];
+  let disposed = false;
+  let compositionEpoch = 0;
+  let resetTimers: Array<ReturnType<typeof setTimeout>> = [];
+
+  const scheduleTimer = (callback: () => void) => {
+    let timerId: ReturnType<typeof setTimeout>;
+    timerId = setTimeout(() => {
+      resetTimers = resetTimers.filter((item) => item !== timerId);
+      callback();
+    }, 0);
+    resetTimers.push(timerId);
+  };
+
+  const scheduleTextareaResetAfterXterm = () => {
+    const epoch = compositionEpoch;
+    scheduleTimer(() => {
+      scheduleTimer(() => {
+        if (disposed || compositionEpoch !== epoch || !textarea.value) return;
+        logger?.("ime.textarea.clear", { valueLength: textarea.value.length });
+        textarea.value = "";
+      });
+    });
+  };
+
+  const addListener = <K extends keyof HTMLElementEventMap>(
+    type: K,
+    handler: (event: HTMLElementEventMap[K]) => void,
+  ) => {
+    textarea.addEventListener(type, handler as EventListener, true);
+    cleanups.push(() => textarea.removeEventListener(type, handler as EventListener, true));
+  };
+
+  addListener("compositionstart", () => {
+    compositionEpoch += 1;
+    guard.compositionStart();
+  });
+  addListener("compositionend", (event) => {
+    guard.compositionEnd(event as CompositionEvent);
+    scheduleTextareaResetAfterXterm();
+  });
+  addListener("beforeinput", (event) => {
+    guard.beforeInput(event as InputEvent);
+  });
+  addListener("input", (event) => {
+    guard.input(event as InputEvent);
+  });
+
+  logger?.("ime.guard.enabled", {});
+
+  return {
+    dispose: () => {
+      disposed = true;
+      while (resetTimers.length > 0) {
+        clearTimeout(resetTimers.pop());
+      }
+      while (cleanups.length > 0) {
+        cleanups.pop()?.();
+      }
+      logger?.("ime.guard.disposed", {});
+    },
+    filterData: guard.filterData,
+  };
+}


### PR DESCRIPTION
## Summary
Fix duplicated and malformed Chinese IME input in terminal panes on Linux/Ubuntu.

On Ubuntu 24.04, when using ibus or fcitx5 inside cc-pane terminal panes, Chinese IME input could be duplicated or partially emitted when running CLI tools such as Claude Code or Codex. This PR adds a Linux-only IME guard for xterm input before forwarding data to the PTY.

## Changes
- Add a Linux-only terminal IME guard attached to xterm's hidden textarea.
- Filter xterm `onData` before calling `terminalService.write`.
- Deduplicate repeated IME commit data from `compositionend` / `input` event ordering.
- Trim cumulative textarea payloads such as `你好你好` so only the new segment is sent.
- Restore suffix-only IME payloads, for example when the candidate is `你好` but xterm emits only `好`.
- Clear stale textarea content after xterm handles `compositionend`.
- Add regression tests for repeated Chinese input, Chinese input after spaces, cumulative payloads, suffix-only payloads, and normal ASCII input.

## Test Plan
- [x] `rtk npx vitest run web/components/panes/terminalImeGuard.test.ts web/components/panes/terminalInputTrace.test.ts web/components/panes/terminalKeyboard.test.ts`
- [x] `rtk npx tsc --noEmit`
- [x] `rtk npm run build`
- [x] Manually tested on Ubuntu 24.04 with Chinese IME input in Claude Code/Codex terminal panes.

## Screenshots
Not applicable.