### PR TITLE
fix: guard linux webkit ime input

### DIFF
--- a/web/components/panes/TerminalView.tsx
+++ b/web/components/panes/TerminalView.tsx
@@ -34,6 +34,7 @@ import {
 import { formatTerminalFilePaths, resolveTerminalPastePayload } from "./terminalClipboard";
 import { isDropInsideTerminalHost } from "./terminalDrop";
 import { attachTerminalInputTrace } from "./terminalInputTrace";
+import { attachTerminalImeGuard, isLinuxWebKitImeEnvironment } from "./terminalImeGuard";
 import { isTerminalPasteShortcut } from "./terminalKeyboard";
 import { createTerminalWriteFlowControl } from "./terminalWriteFlowControl";
 import {
@@ -168,6 +169,7 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     const pasteHandlerRef = useRef<((e: ClipboardEvent) => void) | null>(null);
     const dragDropUnlistenRef = useRef<(() => void) | null>(null);
     const inputTraceRef = useRef<ReturnType<typeof attachTerminalInputTrace> | null>(null);
+    const imeGuardRef = useRef<ReturnType<typeof attachTerminalImeGuard> | null>(null);
     const parserDisposableRefs = useRef<IDisposable[]>([]);
     const writeFlowControlRef = useRef<ReturnType<typeof createTerminalWriteFlowControl> | null>(null);
     const atlasResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -390,6 +392,8 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       }
       inputTraceRef.current?.dispose();
       inputTraceRef.current = null;
+      imeGuardRef.current?.dispose();
+      imeGuardRef.current = null;
 
       // Remove the wheel handler before disposing xterm.
       if (wheelHandlerRef.current && terminalInstanceRef.current?.element) {
@@ -817,6 +821,12 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
             isMac: IS_MAC,
             logger: debugLog,
           });
+          imeGuardRef.current = attachTerminalImeGuard({
+            textarea,
+            terminal: term,
+            enabled: isLinuxWebKitImeEnvironment(),
+            logger: debugLog,
+          });
         }
 
         try {
@@ -857,6 +867,10 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
 
         // Intercept paste so file clipboard data can be resolved through the Tauri backend.
         term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+          if (!imeGuardRef.current?.handleKeyEvent(e)) {
+            return false;
+          }
+
           if (isTerminalPasteShortcut(e, IS_MAC)) {
             e.preventDefault();
             e.stopPropagation();

--- a/web/components/panes/terminalImeGuard.test.ts
+++ b/web/components/panes/terminalImeGuard.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from "vitest";
+import { attachTerminalImeGuard, isLinuxWebKitImeEnvironment } from "./terminalImeGuard";
+
+function createInputEvent(
+  type: "beforeinput" | "input",
+  options: InputEventInit,
+): InputEvent {
+  return new InputEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    ...options,
+  });
+}
+
+function createKeyboardEvent(options: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    ...options,
+  });
+}
+
+function createKeydownEvent(options: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    ...options,
+  });
+}
+
+describe("terminal IME guard", () => {
+  it("detects Linux WebKit without Chromium as the guarded environment", () => {
+    expect(isLinuxWebKitImeEnvironment(
+      "Linux x86_64",
+      "Mozilla/5.0 AppleWebKit/605.1.15 Version/60.5 Safari/605.1.15",
+    )).toBe(true);
+    expect(isLinuxWebKitImeEnvironment(
+      "Linux x86_64",
+      "Mozilla/5.0 AppleWebKit/537.36 Chrome/120 Safari/537.36",
+    )).toBe(false);
+    expect(isLinuxWebKitImeEnvironment(
+      "MacIntel",
+      "Mozilla/5.0 AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15",
+    )).toBe(false);
+  });
+
+  it("forwards only InputEvent.data when compositionstart is missing", () => {
+    const textarea = document.createElement("textarea");
+    const terminal = { input: vi.fn() };
+    const logger = vi.fn();
+    const guard = attachTerminalImeGuard({
+      textarea,
+      terminal,
+      enabled: true,
+      logger,
+      now: () => 1000,
+    });
+
+    textarea.value = "你好 ";
+    textarea.setSelectionRange(3, 3);
+
+    const beforeInput = createInputEvent("beforeinput", {
+      inputType: "insertFromComposition",
+      data: "你好",
+      isComposing: true,
+    });
+    const allowed = textarea.dispatchEvent(beforeInput);
+
+    expect(allowed).toBe(false);
+    expect(beforeInput.defaultPrevented).toBe(true);
+    expect(terminal.input).toHaveBeenCalledWith("你好", true);
+    expect(textarea.value).toBe("");
+    expect(logger).toHaveBeenCalledWith(
+      "ime-guard.malformed-composition.forwarded",
+      expect.objectContaining({
+        source: "beforeinput",
+      }),
+    );
+
+    const input = createInputEvent("input", {
+      inputType: "insertFromComposition",
+      data: "你好",
+      isComposing: true,
+    });
+    textarea.value = "你好 你好";
+    textarea.setSelectionRange(5, 5);
+    textarea.dispatchEvent(input);
+
+    const compositionEnd = new CompositionEvent("compositionend", {
+      data: "你好",
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+    textarea.value = "你好 你好";
+    textarea.dispatchEvent(compositionEnd);
+
+    expect(terminal.input).toHaveBeenCalledTimes(1);
+    expect(input.defaultPrevented).toBe(true);
+    expect(compositionEnd.defaultPrevented).toBe(true);
+    expect(textarea.value).toBe("");
+
+    guard.dispose();
+  });
+
+  it("does not intercept normal composition events with a compositionstart", () => {
+    const textarea = document.createElement("textarea");
+    const terminal = { input: vi.fn() };
+    const guard = attachTerminalImeGuard({
+      textarea,
+      terminal,
+      enabled: true,
+    });
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart", {
+      data: "",
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    }));
+    const beforeInput = createInputEvent("beforeinput", {
+      inputType: "insertFromComposition",
+      data: "你好",
+      isComposing: true,
+    });
+    textarea.dispatchEvent(beforeInput);
+
+    expect(beforeInput.defaultPrevented).toBe(false);
+    expect(terminal.input).not.toHaveBeenCalled();
+
+    guard.dispose();
+  });
+
+  it("suppresses the selection confirmation space after a malformed composition", () => {
+    let currentTime = 1000;
+    const textarea = document.createElement("textarea");
+    const terminal = { input: vi.fn() };
+    const guard = attachTerminalImeGuard({
+      textarea,
+      terminal,
+      enabled: true,
+      now: () => currentTime,
+    });
+
+    textarea.value = "你好 ";
+    textarea.setSelectionRange(3, 3);
+
+    textarea.dispatchEvent(createInputEvent("beforeinput", {
+      inputType: "insertFromComposition",
+      data: "你好",
+      isComposing: true,
+    }));
+
+    const spaceKey = createKeyboardEvent({
+      key: " ",
+      code: "Space",
+      keyCode: 32,
+    });
+    expect(guard.handleKeyEvent(spaceKey)).toBe(false);
+    expect(spaceKey.defaultPrevented).toBe(true);
+
+    const spaceInput = createInputEvent("beforeinput", {
+      inputType: "insertText",
+      data: " ",
+    });
+    textarea.value = "\u00a0";
+    textarea.dispatchEvent(spaceInput);
+
+    expect(spaceInput.defaultPrevented).toBe(true);
+    expect(textarea.value).toBe("");
+    expect(terminal.input).toHaveBeenCalledTimes(1);
+
+    currentTime = 2000;
+    const laterSpaceKey = createKeyboardEvent({
+      key: " ",
+      code: "Space",
+      keyCode: 32,
+    });
+    expect(guard.handleKeyEvent(laterSpaceKey)).toBe(true);
+
+    guard.dispose();
+  });
+
+  it("does not suppress a real space when no selection-space residue was present", () => {
+    let currentTime = 1000;
+    const textarea = document.createElement("textarea");
+    const terminal = { input: vi.fn() };
+    const guard = attachTerminalImeGuard({
+      textarea,
+      terminal,
+      enabled: true,
+      now: () => currentTime,
+    });
+
+    textarea.value = "你好";
+    textarea.setSelectionRange(2, 2);
+
+    textarea.dispatchEvent(createInputEvent("beforeinput", {
+      inputType: "insertFromComposition",
+      data: "你好",
+      isComposing: true,
+    }));
+
+    const spaceKey = createKeyboardEvent({
+      key: " ",
+      code: "Space",
+      keyCode: 32,
+    });
+    expect(guard.handleKeyEvent(spaceKey)).toBe(true);
+    expect(spaceKey.defaultPrevented).toBe(false);
+
+    const spaceInput = createInputEvent("beforeinput", {
+      inputType: "insertText",
+      data: " ",
+    });
+    textarea.dispatchEvent(spaceInput);
+
+    expect(spaceInput.defaultPrevented).toBe(false);
+    expect(terminal.input).toHaveBeenCalledTimes(1);
+
+    currentTime = 1100;
+    const secondSpaceKey = createKeyboardEvent({
+      key: " ",
+      code: "Space",
+      keyCode: 32,
+    });
+    expect(guard.handleKeyEvent(secondSpaceKey)).toBe(true);
+
+    guard.dispose();
+  });
+
+  it("handles input fallback before xterm target listeners", () => {
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    const terminal = { input: vi.fn() };
+    const xtermInputListener = vi.fn();
+
+    textarea.addEventListener("input", xtermInputListener, true);
+
+    const guard = attachTerminalImeGuard({
+      textarea,
+      terminal,
+      enabled: true,
+    });
+
+    textarea.value = "你好";
+    textarea.setSelectionRange(2, 2);
+
+    const input = createInputEvent("input", {
+      inputType: "insertFromComposition",
+      data: "你好",
+      isComposing: true,
+    });
+    const allowed = textarea.dispatchEvent(input);
+
+    expect(allowed).toBe(false);
+    expect(input.defaultPrevented).toBe(true);
+    expect(xtermInputListener).not.toHaveBeenCalled();
+    expect(terminal.input).toHaveBeenCalledWith("你好", true);
+    expect(terminal.input).toHaveBeenCalledTimes(1);
+
+    guard.dispose();
+    textarea.remove();
+  });
+
+  it("skips xterm textarea diff handling when composing after residual spaces", () => {
+    let currentTime = 1000;
+    const textarea = document.createElement("textarea");
+    const terminal = { input: vi.fn() };
+    const logger = vi.fn();
+    const guard = attachTerminalImeGuard({
+      textarea,
+      terminal,
+      enabled: true,
+      logger,
+      now: () => currentTime,
+    });
+
+    textarea.value = "\u00a0";
+    textarea.setSelectionRange(1, 1);
+
+    const imeKeydown = createKeydownEvent({
+      key: "Unidentified",
+      code: "",
+      keyCode: 229,
+    });
+
+    expect(guard.handleKeyEvent(imeKeydown)).toBe(false);
+    expect(imeKeydown.defaultPrevented).toBe(false);
+    expect(logger).toHaveBeenCalledWith(
+      "ime-guard.composition-keydown.skipped",
+      expect.objectContaining({
+        event: expect.objectContaining({
+          key: "Unidentified",
+          keyCode: 229,
+        }),
+      }),
+    );
+
+    const beforeInput = createInputEvent("beforeinput", {
+      inputType: "insertText",
+      data: "你好",
+      isComposing: false,
+    });
+    textarea.dispatchEvent(beforeInput);
+
+    expect(beforeInput.defaultPrevented).toBe(true);
+    expect(terminal.input).toHaveBeenCalledWith("你好", true);
+    expect(textarea.value).toBe("");
+
+    const input = createInputEvent("input", {
+      inputType: "insertText",
+      data: "你好",
+      isComposing: false,
+    });
+    textarea.value = "你好";
+    textarea.dispatchEvent(input);
+
+    expect(input.defaultPrevented).toBe(true);
+    expect(terminal.input).toHaveBeenCalledTimes(1);
+    expect(textarea.value).toBe("");
+
+    currentTime = 2500;
+    const laterInput = createInputEvent("beforeinput", {
+      inputType: "insertText",
+      data: "x",
+    });
+    textarea.dispatchEvent(laterInput);
+
+    expect(laterInput.defaultPrevented).toBe(false);
+
+    guard.dispose();
+  });
+});

--- a/web/components/panes/terminalImeGuard.ts
+++ b/web/components/panes/terminalImeGuard.ts
@@ -1,0 +1,294 @@
+import type { Terminal } from "@xterm/xterm";
+import { summarizeTerminalInputData, type TerminalInputTraceLogger } from "./terminalInputTrace";
+
+const SELECTION_SPACE_SUPPRESS_MS = 250;
+const SELECTION_SPACE_FOLLOWUP_SUPPRESS_MS = 100;
+const SKIPPED_COMPOSITION_KEYDOWN_MS = 1000;
+
+type TerminalInputTarget = Pick<Terminal, "input">;
+
+interface TerminalImeGuardOptions {
+  textarea: HTMLTextAreaElement;
+  terminal: TerminalInputTarget;
+  enabled?: boolean;
+  logger?: TerminalInputTraceLogger;
+  now?: () => number;
+}
+
+export interface TerminalImeGuardController {
+  dispose: () => void;
+  handleKeyEvent: (event: KeyboardEvent) => boolean;
+}
+
+export function isLinuxWebKitImeEnvironment(
+  platform = typeof navigator === "undefined" ? "" : navigator.platform,
+  userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent,
+): boolean {
+  return (
+    /Linux/i.test(platform) &&
+    /AppleWebKit/i.test(userAgent) &&
+    !/(Chrome|Chromium|CriOS|Edg|Firefox)/i.test(userAgent)
+  );
+}
+
+function isInsertFromComposition(event: InputEvent): boolean {
+  return event.inputType === "insertFromComposition" && Boolean(event.data);
+}
+
+function isSpaceKey(event: KeyboardEvent): boolean {
+  return event.key === " " || event.key === "Spacebar";
+}
+
+function isSpaceText(data: string | null): boolean {
+  return data === " " || data === "\u00a0";
+}
+
+function hasTrailingSelectionSpace(data: string, textareaValue: string): boolean {
+  if (!data || !textareaValue) return false;
+  const trimmed = textareaValue.replace(/[ \u00a0]+$/u, "");
+  return trimmed.length < textareaValue.length && trimmed.endsWith(data);
+}
+
+function isImeProcessKey(event: KeyboardEvent): boolean {
+  return event.keyCode === 229 || event.key === "Unidentified";
+}
+
+function stopEvent(event: Event): void {
+  event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation();
+}
+
+function clearTextarea(textarea: HTMLTextAreaElement): void {
+  textarea.value = "";
+  try {
+    textarea.setSelectionRange(0, 0);
+  } catch {
+    // Hidden xterm helper textarea may reject selection changes on some WebViews.
+  }
+}
+
+function eventPayload(event: InputEvent | CompositionEvent | KeyboardEvent, textarea: HTMLTextAreaElement): Record<string, unknown> {
+  const inputEvent = event instanceof InputEvent ? event : null;
+  const compositionEvent = event instanceof CompositionEvent ? event : null;
+  const keyboardEvent = event instanceof KeyboardEvent ? event : null;
+  return {
+    type: event.type,
+    inputType: inputEvent?.inputType,
+    key: keyboardEvent?.key,
+    keyCode: keyboardEvent?.keyCode,
+    data: summarizeTerminalInputData(inputEvent?.data ?? compositionEvent?.data),
+    isComposing: inputEvent?.isComposing ?? keyboardEvent?.isComposing,
+    textarea: {
+      value: summarizeTerminalInputData(textarea.value),
+      valueLength: textarea.value.length,
+      selectionStart: textarea.selectionStart,
+      selectionEnd: textarea.selectionEnd,
+    },
+  };
+}
+
+function noopController(): TerminalImeGuardController {
+  return {
+    dispose: () => {},
+    handleKeyEvent: () => true,
+  };
+}
+
+export function attachTerminalImeGuard(options: TerminalImeGuardOptions): TerminalImeGuardController {
+  if (!options.enabled) return noopController();
+
+  const { textarea, terminal } = options;
+  const now = options.now ?? (() => performance.now());
+  const log = (event: string, payload: Record<string, unknown> = {}) => {
+    options.logger?.(`ime-guard.${event}`, payload);
+  };
+
+  const cleanups: Array<() => void> = [];
+  let sawCompositionStart = false;
+  let handledMalformedComposition = false;
+  let handledSkippedKeydownText = false;
+  let skippedCompositionKeydownUntil = 0;
+  let suppressSelectionSpaceUntil = 0;
+  const handledEvents = new WeakSet<Event>();
+
+  const addListener = <K extends keyof HTMLElementEventMap>(
+    type: K,
+    handler: (event: HTMLElementEventMap[K]) => void,
+  ) => {
+    const wrapped = (event: Event) => {
+      if (event.target !== textarea || handledEvents.has(event)) return;
+      handledEvents.add(event);
+      handler(event as HTMLElementEventMap[K]);
+    };
+
+    // The document capture listener runs before xterm's target capture listener.
+    // Keep the target listener too, so detached textarea tests and unusual DOM paths
+    // still exercise the same guard logic.
+    const ownerDocument = textarea.ownerDocument;
+    ownerDocument.addEventListener(type, wrapped, true);
+    textarea.addEventListener(type, wrapped, true);
+    cleanups.push(() => ownerDocument.removeEventListener(type, wrapped, true));
+    cleanups.push(() => textarea.removeEventListener(type, wrapped, true));
+  };
+
+  const shouldSuppressSelectionSpace = () => suppressSelectionSpaceUntil > 0 && now() <= suppressSelectionSpaceUntil;
+  const hasFreshSkippedCompositionKeydown = () => now() <= skippedCompositionKeydownUntil;
+
+  const markMalformedCompositionHandled = (event: InputEvent, source: "beforeinput" | "input") => {
+    const data = event.data ?? "";
+    const shouldSuppressSelectionSpaceAfterForward = hasTrailingSelectionSpace(data, textarea.value);
+    handledMalformedComposition = true;
+    handledSkippedKeydownText = false;
+    skippedCompositionKeydownUntil = 0;
+    suppressSelectionSpaceUntil = shouldSuppressSelectionSpaceAfterForward
+      ? now() + SELECTION_SPACE_SUPPRESS_MS
+      : 0;
+    stopEvent(event);
+    terminal.input(data, true);
+    clearTextarea(textarea);
+    log("malformed-composition.forwarded", {
+      source,
+      forwarded: summarizeTerminalInputData(data),
+      shouldSuppressSelectionSpaceAfterForward,
+      suppressSelectionSpaceUntil,
+      event: eventPayload(event, textarea),
+    });
+  };
+
+  const markSkippedKeydownTextHandled = (event: InputEvent, source: "beforeinput" | "input") => {
+    const data = event.data ?? "";
+    handledSkippedKeydownText = true;
+    skippedCompositionKeydownUntil = 0;
+    stopEvent(event);
+    terminal.input(data, true);
+    clearTextarea(textarea);
+    log("skipped-keydown-text.forwarded", {
+      source,
+      forwarded: summarizeTerminalInputData(data),
+      event: eventPayload(event, textarea),
+    });
+  };
+
+  const maybeSuppressSelectionSpaceInput = (event: InputEvent, source: "beforeinput" | "input"): boolean => {
+    if (
+      event.inputType !== "insertText" ||
+      !isSpaceText(event.data) ||
+      !shouldSuppressSelectionSpace()
+    ) {
+      return false;
+    }
+
+    stopEvent(event);
+    clearTextarea(textarea);
+    suppressSelectionSpaceUntil = 0;
+    log("selection-space.suppressed", {
+      source,
+      event: eventPayload(event, textarea),
+    });
+    return true;
+  };
+
+  addListener("compositionstart", (event) => {
+    sawCompositionStart = true;
+    handledMalformedComposition = false;
+    handledSkippedKeydownText = false;
+    skippedCompositionKeydownUntil = 0;
+    log("compositionstart", eventPayload(event as CompositionEvent, textarea));
+  });
+
+  addListener("beforeinput", (event) => {
+    const inputEvent = event as InputEvent;
+    if (maybeSuppressSelectionSpaceInput(inputEvent, "beforeinput")) return;
+
+    if (
+      hasFreshSkippedCompositionKeydown() &&
+      inputEvent.inputType === "insertText" &&
+      Boolean(inputEvent.data)
+    ) {
+      markSkippedKeydownTextHandled(inputEvent, "beforeinput");
+      return;
+    }
+
+    if (!sawCompositionStart && isInsertFromComposition(inputEvent)) {
+      markMalformedCompositionHandled(inputEvent, "beforeinput");
+    }
+  });
+
+  addListener("input", (event) => {
+    const inputEvent = event as InputEvent;
+    if (maybeSuppressSelectionSpaceInput(inputEvent, "input")) return;
+
+    if (handledSkippedKeydownText && inputEvent.inputType === "insertText") {
+      stopEvent(inputEvent);
+      clearTextarea(textarea);
+      log("skipped-keydown-text.input-cleared", eventPayload(inputEvent, textarea));
+      return;
+    }
+
+    if (handledMalformedComposition && inputEvent.inputType === "insertFromComposition") {
+      stopEvent(inputEvent);
+      clearTextarea(textarea);
+      log("malformed-composition.input-cleared", eventPayload(inputEvent, textarea));
+      return;
+    }
+
+    if (!sawCompositionStart && isInsertFromComposition(inputEvent)) {
+      markMalformedCompositionHandled(inputEvent, "input");
+    }
+  });
+
+  addListener("compositionend", (event) => {
+    if (handledMalformedComposition) {
+      stopEvent(event);
+      clearTextarea(textarea);
+      log("compositionend.suppressed", eventPayload(event as CompositionEvent, textarea));
+    }
+    sawCompositionStart = false;
+    handledMalformedComposition = false;
+    handledSkippedKeydownText = false;
+    skippedCompositionKeydownUntil = 0;
+  });
+
+  log("enabled", {
+    platform: typeof navigator === "undefined" ? "" : navigator.platform,
+    userAgent: typeof navigator === "undefined" ? "" : navigator.userAgent,
+  });
+
+  return {
+    dispose: () => {
+      while (cleanups.length > 0) {
+        cleanups.pop()?.();
+      }
+      log("disposed", {});
+    },
+    handleKeyEvent: (event: KeyboardEvent) => {
+      if (
+        event.type === "keydown" &&
+        !sawCompositionStart &&
+        isImeProcessKey(event) &&
+        textarea.value.length > 0
+      ) {
+        skippedCompositionKeydownUntil = now() + SKIPPED_COMPOSITION_KEYDOWN_MS;
+        log("composition-keydown.skipped", {
+          skippedCompositionKeydownUntil,
+          event: eventPayload(event, textarea),
+        });
+        return false;
+      }
+
+      if (
+        (event.type === "keydown" || event.type === "keypress") &&
+        isSpaceKey(event) &&
+        shouldSuppressSelectionSpace()
+      ) {
+        stopEvent(event);
+        clearTextarea(textarea);
+        suppressSelectionSpaceUntil = now() + SELECTION_SPACE_FOLLOWUP_SUPPRESS_MS;
+        log("selection-space.key-suppressed", eventPayload(event, textarea));
+        return false;
+      }
+      return true;
+    },
+  };
+}

--- a/web/components/panes/terminalInputTrace.test.ts
+++ b/web/components/panes/terminalInputTrace.test.ts
@@ -23,7 +23,7 @@ describe("terminal input trace", () => {
     expect(isMacPlatform("Linux x86_64")).toBe(false);
   });
 
-  it("requires dev mode, macOS, and an enabled storage flag", () => {
+  it("requires dev mode and an enabled storage flag", () => {
     expect(isTerminalInputTraceEnabled({
       isDev: true,
       isMac: true,
@@ -43,7 +43,7 @@ describe("terminal input trace", () => {
       isDev: true,
       isMac: false,
       storage: storageWith("1"),
-    })).toBe(false);
+    })).toBe(true);
     expect(isTerminalInputTraceEnabled({
       isDev: true,
       isMac: true,
@@ -123,9 +123,17 @@ describe("terminal input trace", () => {
     });
 
     expect(trace.enabled).toBe(true);
-    expect(logger).toHaveBeenCalledWith("input-trace.enabled", {
-      valueLength: 0,
-    });
+    expect(logger).toHaveBeenCalledWith("input-trace.enabled", expect.objectContaining({
+      textarea: expect.objectContaining({
+        valueLength: 0,
+        value: {
+          text: "",
+          length: 0,
+          codePoints: [],
+          truncated: false,
+        },
+      }),
+    }));
 
     textarea.value = "!";
     textarea.dispatchEvent(new KeyboardEvent("keydown", {
@@ -152,7 +160,15 @@ describe("terminal input trace", () => {
       code: "Digit1",
       keyCode: 49,
       shiftKey: true,
-      valueLength: 1,
+      textarea: expect.objectContaining({
+        valueLength: 1,
+        value: {
+          text: "!",
+          length: 1,
+          codePoints: ["21"],
+          truncated: false,
+        },
+      }),
     }));
     expect(logger).toHaveBeenCalledWith("input-trace.beforeinput", expect.objectContaining({
       inputType: "insertText",
@@ -163,7 +179,9 @@ describe("terminal input trace", () => {
         truncated: false,
       },
       isComposing: true,
-      valueLength: 1,
+      textarea: expect.objectContaining({
+        valueLength: 1,
+      }),
     }));
     expect(logger).toHaveBeenCalledWith("input-trace.compositionend", expect.objectContaining({
       data: {
@@ -172,16 +190,21 @@ describe("terminal input trace", () => {
         codePoints: ["21"],
         truncated: false,
       },
-      valueLength: 1,
+      textarea: expect.objectContaining({
+        valueLength: 1,
+      }),
     }));
-    expect(logger).toHaveBeenCalledWith("input-trace.onData", {
+    expect(logger).toHaveBeenCalledWith("input-trace.onData", expect.objectContaining({
       data: {
         text: "!",
         length: 1,
         codePoints: ["21"],
         truncated: false,
       },
-    });
+      textarea: expect.objectContaining({
+        valueLength: 1,
+      }),
+    }));
   });
 
   it("removes listeners on dispose", () => {

--- a/web/components/panes/terminalInputTrace.ts
+++ b/web/components/panes/terminalInputTrace.ts
@@ -16,6 +16,7 @@ export interface TerminalInputTraceController {
 interface TerminalInputTraceOptions {
   textarea?: HTMLTextAreaElement | null;
   isDev: boolean;
+  /** Kept for older call sites; tracing is platform-independent when enabled. */
   isMac: boolean;
   logger: TerminalInputTraceLogger;
   storage?: TraceStorage | null;
@@ -36,14 +37,13 @@ function getDefaultStorage(): TraceStorage | null {
 
 export function isTerminalInputTraceEnabled({
   isDev,
-  isMac,
   storage = getDefaultStorage(),
 }: {
   isDev: boolean;
   isMac: boolean;
   storage?: TraceStorage | null;
 }): boolean {
-  if (!isDev || !isMac || !storage) return false;
+  if (!isDev || !storage) return false;
   try {
     const value = storage.getItem(TERMINAL_INPUT_TRACE_STORAGE_KEY);
     return value === "1" || value === "true";
@@ -70,6 +70,25 @@ export function summarizeTerminalInputData(value: string | null | undefined): Re
   };
 }
 
+function getNavigatorDiagnostics(): Record<string, unknown> {
+  if (typeof navigator === "undefined") return {};
+  return {
+    platform: navigator.platform,
+    userAgent: navigator.userAgent,
+    language: navigator.language,
+    languages: navigator.languages,
+  };
+}
+
+function textareaPayload(textarea: HTMLTextAreaElement): Record<string, unknown> {
+  return {
+    value: summarizeTerminalInputData(textarea.value),
+    valueLength: textarea.value.length,
+    selectionStart: textarea.selectionStart,
+    selectionEnd: textarea.selectionEnd,
+  };
+}
+
 function keyboardPayload(event: KeyboardEvent, textarea: HTMLTextAreaElement): Record<string, unknown> {
   return {
     type: event.type,
@@ -83,8 +102,10 @@ function keyboardPayload(event: KeyboardEvent, textarea: HTMLTextAreaElement): R
     shiftKey: event.shiftKey,
     altKey: event.altKey,
     metaKey: event.metaKey,
+    composed: event.composed,
+    isTrusted: event.isTrusted,
     defaultPrevented: event.defaultPrevented,
-    valueLength: textarea.value.length,
+    textarea: textareaPayload(textarea),
   };
 }
 
@@ -94,8 +115,10 @@ function inputPayload(event: InputEvent, textarea: HTMLTextAreaElement): Record<
     inputType: event.inputType,
     data: summarizeTerminalInputData(event.data),
     isComposing: event.isComposing,
+    composed: event.composed,
+    isTrusted: event.isTrusted,
     defaultPrevented: event.defaultPrevented,
-    valueLength: textarea.value.length,
+    textarea: textareaPayload(textarea),
   };
 }
 
@@ -103,8 +126,10 @@ function compositionPayload(event: CompositionEvent, textarea: HTMLTextAreaEleme
   return {
     type: event.type,
     data: summarizeTerminalInputData(event.data),
+    composed: event.composed,
+    isTrusted: event.isTrusted,
     defaultPrevented: event.defaultPrevented,
-    valueLength: textarea.value.length,
+    textarea: textareaPayload(textarea),
   };
 }
 
@@ -132,6 +157,13 @@ export function attachTerminalInputTrace(
   }
 
   const cleanups: Array<() => void> = [];
+  let sequence = 0;
+  const log = (event: string, payload: Record<string, unknown> = {}) => {
+    logger(event, {
+      seq: ++sequence,
+      ...payload,
+    });
+  };
 
   const addListener = <K extends keyof HTMLElementEventMap>(
     type: K,
@@ -142,29 +174,30 @@ export function attachTerminalInputTrace(
   };
 
   addListener("keydown", (event) => {
-    logger("input-trace.keydown", keyboardPayload(event as KeyboardEvent, textarea));
+    log("input-trace.keydown", keyboardPayload(event as KeyboardEvent, textarea));
   });
   addListener("keypress", (event) => {
-    logger("input-trace.keypress", keyboardPayload(event as KeyboardEvent, textarea));
+    log("input-trace.keypress", keyboardPayload(event as KeyboardEvent, textarea));
   });
   addListener("beforeinput", (event) => {
-    logger("input-trace.beforeinput", inputPayload(event as InputEvent, textarea));
+    log("input-trace.beforeinput", inputPayload(event as InputEvent, textarea));
   });
   addListener("input", (event) => {
-    logger("input-trace.input", inputPayload(event as InputEvent, textarea));
+    log("input-trace.input", inputPayload(event as InputEvent, textarea));
   });
   addListener("compositionstart", (event) => {
-    logger("input-trace.compositionstart", compositionPayload(event as CompositionEvent, textarea));
+    log("input-trace.compositionstart", compositionPayload(event as CompositionEvent, textarea));
   });
   addListener("compositionupdate", (event) => {
-    logger("input-trace.compositionupdate", compositionPayload(event as CompositionEvent, textarea));
+    log("input-trace.compositionupdate", compositionPayload(event as CompositionEvent, textarea));
   });
   addListener("compositionend", (event) => {
-    logger("input-trace.compositionend", compositionPayload(event as CompositionEvent, textarea));
+    log("input-trace.compositionend", compositionPayload(event as CompositionEvent, textarea));
   });
 
-  logger("input-trace.enabled", {
-    valueLength: textarea.value.length,
+  log("input-trace.enabled", {
+    textarea: textareaPayload(textarea),
+    navigator: getNavigatorDiagnostics(),
   });
 
   return {
@@ -173,11 +206,12 @@ export function attachTerminalInputTrace(
       while (cleanups.length > 0) {
         cleanups.pop()?.();
       }
-      logger("input-trace.disposed", {});
+      log("input-trace.disposed", {});
     },
     onData: (data: string) => {
-      logger("input-trace.onData", {
+      log("input-trace.onData", {
         data: summarizeTerminalInputData(data),
+        textarea: textareaPayload(textarea),
       });
     },
   };


### PR DESCRIPTION
## Summary

Fix Linux WebKitGTK IME input handling in the xterm frontend path.

This PR fixes the CC-Panes input integration root cause where malformed Linux WebKitGTK IME commit sequences could fall through to xterm's textarea diff fallback and emit an unintended `DEL` byte (`\x7f`). The fix is intentionally scoped to the frontend terminal input layer and does not change PTY, backend, CLI, or session write behavior.

## Root Cause

On Linux WebKitGTK with IMEs such as fcitx5/ibus, the browser may deliver an IME commit sequence that does not match xterm's expected composition lifecycle:

- `compositionstart` may be missing
- `insertFromComposition` may still arrive with committed text
- xterm's helper textarea may retain committed text plus a trailing space/NBSP
- a later `keydown` with `keyCode=229` can enter xterm's non-composing textarea diff path
- when that helper textarea becomes shorter, xterm interprets it as deletion and sends `DEL` (`\x7f`)

Within CC-Panes, the root issue was that this Linux WebKitGTK-specific IME sequence was not detected before xterm's fallback diff logic ran.

## What Changed

Added a Linux WebKitGTK-specific IME guard for xterm terminals:

- Enables only on `Linux + AppleWebKit`, excluding Chrome/Chromium/Edge/Firefox
- Leaves normal `compositionstart` flows untouched
- Handles missing-`compositionstart` IME commits via `InputEvent.data`
- Sends committed text directly through `terminal.input(data, true)`
- Clears xterm's helper textarea after handled commits
- Suppresses duplicate follow-up `input` / `compositionend` events
- Blocks xterm's textarea diff fallback for residual IME textarea state after `keyCode=229`
- Narrows candidate-confirmation space suppression to cases with clear residual textarea evidence
- Adds capture-phase input fallback with de-duping so the guard can run before xterm's textarea listener

Also expanded terminal input tracing so Linux reproductions can be captured in development builds with the existing localStorage flag.

## Files Changed

- `web/components/panes/TerminalView.tsx`
- `web/components/panes/terminalImeGuard.ts`
- `web/components/panes/terminalImeGuard.test.ts`
- `web/components/panes/terminalInputTrace.ts`
- `web/components/panes/terminalInputTrace.test.ts`

## Validation

Ran:

```bash
npm run test:run -- terminalImeGuard terminalInputTrace
npx tsc --noEmit
git diff --check
```

## Platform Impact

The functional IME guard is platform-gated and should not affect macOS or Windows terminal input behavior.

The only cross-platform behavior change is diagnostic tracing in development builds: the existing terminal input trace flag can now be used outside macOS to help capture Linux IME event sequences.

## Notes

This PR is a CC-Panes application-layer compatibility fix. It prevents the bad IME event sequence from reaching xterm's textarea diff fallback in this app. Longer-term upstream improvements may still be possible in WebKitGTK event consistency and xterm IME fallback robustness.