### PR TITLE
fix(sidebar): prevent React error #185 by moving async calls outside …

### DIFF
--- a/web/components/sidebar/useWorkspaceActions.ts
+++ b/web/components/sidebar/useWorkspaceActions.ts
@@ -107,18 +107,15 @@ export function useWorkspaceActions({ onOpenTerminal }: UseWorkspaceActionsParam
     const ws = currentWorkspaces.find((w) => w.id === expandedWorkspaceId);
     if (!ws) return;
     for (const project of ws.projects) {
-      setGitBranches((prev) => {
-        if (project.path in prev) return prev;
+      // 在 state updater 外部检查是否需要获取
+      if (!(project.path in gitBranches)) {
         fetchGitBranch(project.path).then((branch) => {
           setGitBranches((p) => ({ ...p, [project.path]: branch }));
         });
-        return prev;
-      });
-      setWorktreeCache((prev) => {
-        if (project.path in prev) return prev;
+      }
+      if (!(project.path in worktreeCache)) {
         fetchWorktrees(project.path);
-        return prev;
-      });
+      }
     }
   }, [expandedWorkspaceId, fetchGitBranch, fetchWorktrees]);
 


### PR DESCRIPTION
  PR 标题：
  fix(sidebar): prevent React error #185 by moving async calls outside setState updater

  PR 描述：
  ## Summary

  修复了在侧边栏展开工作空间时触发的 React error #185（Maximum update depth exceeded）。

  ## Problem

  在 `useWorkspaceActions.ts` 的 useEffect 中，`fetchGitBranch()` 和 `fetchWorktrees()` 在 `setState` 的 updater
  函数内部被调用。这导致多个异步操作同时更新 state，React 会认为这是无限循环。

  **错误信息：**
  Minified React error #185; visit https://react.dev/errors/185 for the full message

  ## Solution

  将异步调用移到 state updater 函数外部：
  - ✅ 在 state updater 外部检查是否需要获取数据
  - ✅ 在 Promise 的 `.then()` 回调中更新 state（正确的异步模式）
  - ✅ 避免在 state updater 中调用异步函数
  - ✅ 防止多个异步操作同时更新 state 造成无限循环

  ## Test Plan

  - [ ] 在侧边栏展开工作空间，验证不再出现 React error
  - [ ] 测试快速展开/折叠多个工作空间
  - [ ] 测试有多个项目的工作空间的展开