### PR TITLE
fix(ui): Ubuntu 下点击右上角关闭按钮无反应（Linux/WebKitGTK 窗口控制按钮失效）

### DIFF
--- a/web/components/TitleBar.tsx
+++ b/web/components/TitleBar.tsx
@@ -8,6 +8,12 @@ interface TitleBarProps {
 }
 
 const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+// Linux/WebKitGTK 原生支持 -webkit-app-region，但对 drag 区域内的 no-drag 子区域
+// 识别有缺陷：父级标题栏设为 drag 后，右上角窗口控制按钮（关闭/最小化/最大化）
+// 会收不到点击事件（Ubuntu 上表现为点关闭按钮没反应）。因此 Linux 下不使用
+// -webkit-app-region，改为仅依赖 data-tauri-drag-region 实现拖拽（其按 target
+// 命中判断，不会拦截按钮点击）。参考同类 Linux WebKit 适配 isLinuxWebKitImeEnvironment。
+const isLinux = navigator.platform.toUpperCase().indexOf("LINUX") >= 0;
 
 export default function TitleBar({ workspaceName }: TitleBarProps) {
   const { t } = useTranslation("common");
@@ -28,7 +34,8 @@ export default function TitleBar({ workspaceName }: TitleBarProps) {
         borderBottom: "1px solid var(--app-border)",
         backdropFilter: `blur(var(--app-glass-blur))`,
         WebkitBackdropFilter: `blur(var(--app-glass-blur))`,
-        WebkitAppRegion: "drag",
+        // Linux 下省略 -webkit-app-region（详见文件顶部 isLinux 说明），避免吞掉窗口控制按钮的点击
+        ...(isLinux ? {} : { WebkitAppRegion: "drag" }),
       } as React.CSSProperties}
     >
       {/* 顶部高光线 */}


### PR DESCRIPTION
## 问题

Ubuntu 系统上启动软件后，点击右上角的**关闭按钮没反应**（最小化/最大化按钮同样点不动）。

## 根因

标题栏父元素 `web/components/TitleBar.tsx` 同时设置了 `data-tauri-drag-region` 和 `-webkit-app-region: drag`（后者在 `1cbc477` 中为「提升原生拖拽可靠性」引入）。

- **WebKitGTK（Linux）原生支持 `-webkit-app-region`**，会把整条标题栏变成原生拖拽区；但它对 `drag` 区域内 `no-drag` 子区域的识别存在缺陷，导致右上角的关闭/最小化/最大化按钮收不到点击事件，`closeWindow` / `minimizeWindow` / `maximizeWindow` 始终不会被触发。
- 关闭路径本身是正常的：`close_window` → `window.close()` → `CloseRequested`，而 Linux 下 `should_close_main_window_to_tray` 返回 `false`，会走 `exit(0)`。也就是说**只要点击能到达按钮就能正常关闭**，问题完全出在点击事件被拖拽区吞掉。

为什么只在 Linux 出现：
| 平台 | 表现 |
| --- | --- |
| **Linux / WebKitGTK** | 原生识别 `-webkit-app-region`，`no-drag` 失效 → 按钮点不动 ❌ |
| **Windows / WebView2** | 忽略 `-webkit-app-region`，拖拽由 `data-tauri-drag-region` 处理 → 正常 ✅ |
| **macOS** | 使用原生红绿灯，不渲染这些自定义按钮 → 不受影响 ✅ |

## 修复

Linux 下不再使用 `-webkit-app-region`，仅依赖 `data-tauri-drag-region` 实现拖拽（其按事件 `target` 命中判断，不会拦截子按钮的点击）。macOS / Windows 行为保持不变。

```tsx
const isLinux = navigator.platform.toUpperCase().indexOf("LINUX") >= 0;
// ...
// Linux 下省略 -webkit-app-region，避免吞掉窗口控制按钮的点击
...(isLinux ? {} : { WebkitAppRegion: "drag" }),
```

与仓库既有的 Linux/WebKitGTK 适配（如 `isLinuxWebKitImeEnvironment`）思路一致。

## 影响范围

- 仅改动 `web/components/TitleBar.tsx`，单文件、8 行。
- Linux 拖拽仍可用：标题栏空白区由 `data-tauri-drag-region` 拖拽，中间留白区另有 `onMouseDown → startDragging()` 兜底。
- macOS / Windows 完全无行为变化。

## 验证

- [x] 代码审查 + 现有 `TitleBar.test.tsx` 用例逻辑不受影响（按钮 onClick 接线未改动）。
- [ ] 建议在 Ubuntu（WebKitGTK）上实机回归：关闭/最小化/最大化按钮可点击，标题栏拖拽正常。

> 我无 Linux 实机环境，根因与修复基于代码与 WebKitGTK `-webkit-app-region` 行为推断，烦请在 Ubuntu 上确认一次。
