### PR TITLE
fix: align OpenAI provider type serialization

### DIFF
--- a/cc-panes-core/src/models/provider.rs
+++ b/cc-panes-core/src/models/provider.rs
@@ -18,6 +18,7 @@ pub enum ProviderType {
     Vertex,
     Proxy,
     ConfigProfile,
+    #[serde(rename = "open_ai", alias = "open_a_i")]
     OpenAI,
     Gemini,
     Kimi,
@@ -187,4 +188,25 @@ pub struct SystemProviderInfo {
     pub env_keys: Vec<String>,
     /// 用户已把「系统环境变量」设为默认凭证（持久化状态）。
     pub default_is_system: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProviderType;
+
+    #[test]
+    fn open_ai_uses_canonical_name_and_accepts_legacy_name() {
+        assert_eq!(
+            serde_json::from_str::<ProviderType>(r#""open_ai""#).unwrap(),
+            ProviderType::OpenAI
+        );
+        assert_eq!(
+            serde_json::from_str::<ProviderType>(r#""open_a_i""#).unwrap(),
+            ProviderType::OpenAI
+        );
+        assert_eq!(
+            serde_json::to_string(&ProviderType::OpenAI).unwrap(),
+            r#""open_ai""#
+        );
+    }
 }


### PR DESCRIPTION
## Root cause

`ProviderType` uses `#[serde(rename_all = "snake_case")]`. Serde splits the `OpenAI` acronym as `open_a_i`, while the frontend, Tauri payload contract, and CLI adapters use `open_ai`, so `add_provider` rejects the frontend payload as an unknown variant.

## Compatibility strategy

- Serialize `ProviderType::OpenAI` with the canonical value `open_ai`.
- Accept `open_a_i` as a deserialization-only alias so existing persisted configurations remain readable.
- Keep frontend, Tauri IPC, persistence, and CLI adapter contracts aligned on `open_ai`.

## Tests

- `cargo test -p cc-panes-core`: passed, 684 tests, 0 failed.
- `cargo check -p cc-panes-core`: passed.
- `git diff --check`: passed.
- Modified file `rustfmt --check`: passed.
- `cargo fmt --all -- --check`: blocked by pre-existing formatting differences on `main` in `cc-cli-adapters/src/claude.rs`, `cc-panes-core/src/services/shared_mcp_service.rs`, and `cc-panes-core/src/services/workspace_service.rs`; this PR does not modify those files.