### PR TITLE
fix(provider): 让 Codex 终端真实使用所选 Provider

### DIFF
--- a/cc-cli-adapters/src/codex.rs
+++ b/cc-cli-adapters/src/codex.rs
@@ -23,6 +23,7 @@ const PLAN_ARCHIVE_UNSUPPORTED: &str =
     "Codex does not support CC-Panes plan archive yet; only session-start is available.";
 const CC_PANE_EVENT_UNSUPPORTED: &str =
     "Codex CLI does not expose this hook event yet. Only SessionStart and PostToolUse are usable.";
+const CCPANES_CODEX_API_KEY_ENV: &str = "CCPANES_CODEX_API_KEY";
 
 struct HookDef {
     name: &'static str,
@@ -108,6 +109,84 @@ impl CodexAdapter {
 
     fn format_toml_string_for_cli(value: &str) -> String {
         serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+    }
+
+    fn codex_provider_id(provider_id: &str) -> String {
+        let suffix = provider_id
+            .chars()
+            .map(|ch| {
+                if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+                    ch
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>();
+        let suffix = suffix.trim_matches('_');
+        if suffix.is_empty() {
+            "ccpanes_selected".to_string()
+        } else {
+            format!("ccpanes_{suffix}")
+        }
+    }
+
+    /// Apply the selected CC-Panes OpenAI provider as Codex per-launch config.
+    ///
+    /// `CODEX_API_KEY` and `OPENAI_BASE_URL` alone do not select a custom Codex
+    /// model provider when `config.toml` already declares `model_provider`.
+    /// These overrides make the launch deterministic while keeping the API key
+    /// in the process environment rather than in command-line arguments.
+    pub fn push_provider_overrides(
+        args: &mut Vec<String>,
+        env_inject: &mut HashMap<String, String>,
+        provider: Option<&crate::CliProvider>,
+    ) {
+        let Some(provider) = provider.filter(|provider| provider.provider_type == "open_ai") else {
+            return;
+        };
+
+        let provider_id = Self::codex_provider_id(&provider.id);
+        let provider_key = Self::format_toml_key_segment_for_cli(&provider_id);
+        let mut push = |value: String| {
+            args.push("-c".to_string());
+            args.push(value);
+        };
+
+        push(format!(
+            "model_provider={}",
+            Self::format_toml_string_for_cli(&provider_id)
+        ));
+        push(format!(
+            "model_providers.{provider_key}.name={}",
+            Self::format_toml_string_for_cli(&provider.name)
+        ));
+        if let Some(base_url) = provider
+            .base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            push(format!(
+                "model_providers.{provider_key}.base_url={}",
+                Self::format_toml_string_for_cli(base_url)
+            ));
+        }
+        if let Some(api_key) = provider
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            env_inject.insert(CCPANES_CODEX_API_KEY_ENV.to_string(), api_key.to_string());
+            push(format!(
+                "model_providers.{provider_key}.env_key={}",
+                Self::format_toml_string_for_cli(CCPANES_CODEX_API_KEY_ENV)
+            ));
+        }
+        push(format!(
+            "model_providers.{provider_key}.wire_api={}",
+            Self::format_toml_string_for_cli("responses")
+        ));
     }
 
     fn push_mcp_url_override(args: &mut Vec<String>, name: &str, url: &str) {
@@ -1275,7 +1354,7 @@ impl CliToolAdapter for CodexAdapter {
 
     fn build_command(&self, ctx: &CliAdapterContext) -> Result<CliCommandResult> {
         let mut args = Vec::new();
-        let env_inject = HashMap::new();
+        let mut env_inject = HashMap::new();
 
         // 不隔离 CODEX_HOME：Codex 直接使用真实 ~/.codex（与 Claude 一致），
         // 这样 `codex resume <id>` 能命中真实 sessions、ccswitch 换 provider 后历史不丢。
@@ -1284,6 +1363,8 @@ impl CliToolAdapter for CodexAdapter {
         Self::migrate_legacy_isolated_sessions();
         Self::migrate_stale_global_ccpanes_mcp_config();
         Self::ensure_yolo_local_project_trust(ctx);
+
+        Self::push_provider_overrides(&mut args, &mut env_inject, ctx.provider.as_ref());
 
         // MCP 注入使用 Codex 的 per-launch -c override，避免写入用户全局 config.toml。
         if ctx.skip_mcp {
@@ -1492,6 +1573,62 @@ mod tests {
             .windows(2)
             .any(|pair| pair[0] == "resume" && pair[1] == "thread-123"));
         assert_eq!(result.args.last().map(String::as_str), Some("hello"));
+    }
+
+    #[test]
+    fn build_command_selects_explicit_open_ai_provider() {
+        let adapter = CodexAdapter::new();
+        let mut ctx = test_context(Some("codex-test"));
+        ctx.provider = Some(crate::CliProvider {
+            id: "provider/ai".to_string(),
+            name: "ai".to_string(),
+            provider_type: "open_ai".to_string(),
+            api_key: Some("secret-provider-key".to_string()),
+            base_url: Some("https://provider.example/v1".to_string()),
+            ..Default::default()
+        });
+
+        let result = adapter.build_command(&ctx).unwrap();
+
+        assert!(result
+            .args
+            .iter()
+            .any(|arg| { arg == "model_provider=\"ccpanes_provider_ai\"" }));
+        assert!(result.args.iter().any(|arg| {
+            arg == "model_providers.ccpanes_provider_ai.base_url=\"https://provider.example/v1\""
+        }));
+        assert!(result.args.iter().any(|arg| {
+            arg == "model_providers.ccpanes_provider_ai.env_key=\"CCPANES_CODEX_API_KEY\""
+        }));
+        assert!(result
+            .args
+            .iter()
+            .any(|arg| { arg == "model_providers.ccpanes_provider_ai.wire_api=\"responses\"" }));
+        assert_eq!(
+            result
+                .env_inject
+                .get("CCPANES_CODEX_API_KEY")
+                .map(String::as_str),
+            Some("secret-provider-key")
+        );
+        assert!(!result
+            .args
+            .iter()
+            .any(|arg| arg.contains("secret-provider-key")));
+    }
+
+    #[test]
+    fn build_command_leaves_local_codex_provider_untouched_without_selection() {
+        let adapter = CodexAdapter::new();
+        let ctx = test_context(Some("codex-test"));
+
+        let result = adapter.build_command(&ctx).unwrap();
+
+        assert!(!result
+            .args
+            .iter()
+            .any(|arg| arg.starts_with("model_provider=")));
+        assert!(!result.env_inject.contains_key("CCPANES_CODEX_API_KEY"));
     }
 
     #[test]

--- a/cc-panes-core/src/services/provider_service.rs
+++ b/cc-panes-core/src/services/provider_service.rs
@@ -49,8 +49,35 @@ impl ProviderService {
         Ok(())
     }
 
+    /// Refresh the in-memory snapshot before reads.
+    ///
+    /// The desktop process and the long-lived daemon each own a separate
+    /// `ProviderService`. Provider edits are written atomically by the desktop
+    /// process, so re-reading here makes the next daemon launch observe them
+    /// without requiring an application or daemon restart.
+    fn refresh_from_file(&self) {
+        let mut cached = self.config.lock().unwrap_or_else(|e| e.into_inner());
+        if !self.config_path.is_file() {
+            return;
+        }
+
+        match Self::load_from_file(&self.config_path) {
+            Ok(config) => {
+                *cached = config;
+            }
+            Err(error) => {
+                warn!(
+                    path = %self.config_path.display(),
+                    error = %error,
+                    "[ProviderService] Failed to refresh providers config; keeping cached snapshot"
+                );
+            }
+        }
+    }
+
     /// 列出所有 Provider
     pub fn list_providers(&self) -> Vec<Provider> {
+        self.refresh_from_file();
         self.config
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -60,6 +87,7 @@ impl ProviderService {
 
     /// 获取指定 Provider
     pub fn get_provider(&self, id: &str) -> Option<Provider> {
+        self.refresh_from_file();
         self.config
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -71,6 +99,7 @@ impl ProviderService {
 
     /// 获取默认 Provider
     pub fn get_default_provider(&self) -> Option<Provider> {
+        self.refresh_from_file();
         let config = self.config.lock().unwrap_or_else(|e| e.into_inner());
         config
             .providers
@@ -114,6 +143,7 @@ impl ProviderService {
     /// 只回传命中的**变量名**，绝不回传值——凭证不出后端。
     pub fn system_provider_info(&self) -> SystemProviderInfo {
         let (cc_switch, env_keys) = Self::probe_system_provider();
+        self.refresh_from_file();
         let default_is_system = self
             .config
             .lock()
@@ -265,6 +295,8 @@ impl ProviderService {
             return HashMap::new();
         }
 
+        self.refresh_from_file();
+
         let config = self.config.lock().unwrap_or_else(|e| e.into_inner());
 
         let provider = if let Some(id) = provider_id {
@@ -387,6 +419,28 @@ mod tests {
             config_dir,
             is_default: false,
         }
+    }
+
+    #[test]
+    fn separate_service_instances_observe_provider_file_updates() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("providers.json");
+        let daemon_service = ProviderService::new(path.clone());
+        let desktop_service = ProviderService::new(path);
+
+        desktop_service
+            .add_provider(make_provider("fresh-provider", true))
+            .unwrap();
+
+        let observed = daemon_service.get_provider("fresh-provider").unwrap();
+        assert_eq!(observed.name, "Provider fresh-provider");
+        assert_eq!(
+            daemon_service
+                .get_env_vars(Some("fresh-provider"))
+                .get("ANTHROPIC_API_KEY")
+                .map(String::as_str),
+            Some("sk-fresh-provider")
+        );
     }
 
     fn new_service(dir: &tempfile::TempDir) -> ProviderService {

--- a/cc-panes-core/src/services/terminal_service.rs
+++ b/cc-panes-core/src/services/terminal_service.rs
@@ -1665,8 +1665,13 @@ impl TerminalService {
             // SSH 模式：cwd 用本机 home dir，命令通过 ssh 连接远程
             // 跳过 MCP 注入、Orchestrator 信息注入、--add-dir、--resume、--append-system-prompt
             let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-            let (cmd, cmd_args) =
-                self.build_ssh_command(ssh_info, cli_tool, &provider_vars, effective_yolo_mode)?;
+            let (cmd, cmd_args) = self.build_ssh_command(
+                ssh_info,
+                cli_tool,
+                &provider_vars,
+                provider.as_ref(),
+                effective_yolo_mode,
+            )?;
             info!(
                 session_id = %session_id,
                 host = %ssh_info.host,
@@ -1837,6 +1842,7 @@ impl TerminalService {
                         &session_id,
                         &env_vars,
                         &provider_vars,
+                        provider.as_ref(),
                         resume_id,
                         launch_append_system_prompt.as_deref(),
                         initial_prompt,
@@ -3195,6 +3201,7 @@ impl TerminalService {
         ssh: &SshConnectionInfo,
         cli_tool: CliTool,
         provider_env: &HashMap<String, String>,
+        provider: Option<&CliProvider>,
         yolo_mode: bool,
     ) -> Result<(String, Vec<String>)> {
         let ssh_path = cached_which("ssh").map_err(|_| anyhow!("ssh not found in PATH"))?;
@@ -3217,10 +3224,19 @@ impl TerminalService {
 
         // 构建远程命令
         let mut remote_parts: Vec<String> = Vec::new();
+        let mut provider_env = provider_env.clone();
+        let mut codex_provider_args = Vec::new();
+        if cli_tool == CliTool::Codex {
+            cc_cli_adapters::CodexAdapter::push_provider_overrides(
+                &mut codex_provider_args,
+                &mut provider_env,
+                provider,
+            );
+        }
 
         // Provider 环境变量注入（白名单 key 格式 + value 转义）
         if cli_tool != CliTool::None {
-            for (k, v) in provider_env {
+            for (k, v) in &provider_env {
                 if Self::is_valid_env_key(k) {
                     remote_parts.push(format!("export {}={}", k, Self::shell_escape(v)));
                 } else {
@@ -3234,7 +3250,12 @@ impl TerminalService {
             let escaped_path = Self::shell_escape(&ssh.remote_path);
             remote_parts.push(format!("cd {}", escaped_path));
         }
-        remote_parts.push(Self::ssh_remote_cli_command(cli_tool, yolo_mode).to_string());
+        let mut remote_cli = Self::ssh_remote_cli_command(cli_tool, yolo_mode).to_string();
+        for arg in codex_provider_args {
+            remote_cli.push(' ');
+            remote_cli.push_str(&Self::shell_escape(&arg));
+        }
+        remote_parts.push(remote_cli);
         args.push(remote_parts.join(" && "));
 
         Ok((ssh_path.to_string_lossy().into_owned(), args))

--- a/cc-panes-core/src/services/terminal_service/wsl_codex.rs
+++ b/cc-panes-core/src/services/terminal_service/wsl_codex.rs
@@ -1224,6 +1224,7 @@ impl TerminalService {
         session_id: &str,
         env_vars: &HashMap<String, String>,
         provider_env: &HashMap<String, String>,
+        provider: Option<&cc_cli_adapters::CliProvider>,
         resume_id: Option<&str>,
         append_system_prompt: Option<&str>,
         initial_prompt: Option<&str>,
@@ -1236,7 +1237,14 @@ impl TerminalService {
         adapter_options: &HashMap<String, serde_json::Value>,
     ) -> Result<(String, Vec<String>)> {
         let mut remote_parts = Vec::new();
-        push_wsl_env_exports(&mut remote_parts, provider_env);
+        let mut provider_env = provider_env.clone();
+        let mut codex_args = Vec::new();
+        cc_cli_adapters::CodexAdapter::push_provider_overrides(
+            &mut codex_args,
+            &mut provider_env,
+            provider,
+        );
+        push_wsl_env_exports(&mut remote_parts, &provider_env);
         push_wsl_ccpanes_env_exports(&mut remote_parts, env_vars);
         push_wsl_codex_mcp_isolation_prelude(
             &mut remote_parts,
@@ -1253,8 +1261,6 @@ impl TerminalService {
         }
 
         let codex_path = "codex";
-
-        let mut codex_args = Vec::new();
 
         if !skip_mcp {
             let proxy = super::wsl_mcp_proxy::invocation(
@@ -1426,6 +1432,7 @@ impl TerminalService {
         _session_id: &str,
         _env_vars: &HashMap<String, String>,
         _provider_env: &HashMap<String, String>,
+        _provider: Option<&cc_cli_adapters::CliProvider>,
         _resume_id: Option<&str>,
         _append_system_prompt: Option<&str>,
         _initial_prompt: Option<&str>,


### PR DESCRIPTION
## 问题

在 CC-Panes 里为 Codex 终端显式选择 OpenAI Provider 后，启动历史会记录该 Provider，但实际 Codex 仍可能使用本机 `config.toml` 中的 `model_provider`：

1. desktop 与 daemon 各自持有独立的 `ProviderService` 内存快照，daemon 启动后新增/修改的 Provider 不会进入其旧快照。
2. 原实现只注入 `CODEX_API_KEY` / `OPENAI_BASE_URL`；Codex 已配置 `model_provider` 时，这两个环境变量不会切换有效 Model Provider。

## 修复

- Provider 读取前刷新原子写入的 `providers.json`，使长驻 daemon 的下一次启动立即看到 desktop 端变更；刷新失败时保留上一份有效快照。
- Codex 启动时注入 per-launch 配置：
  - `model_provider`
  - `model_providers.<id>.name`
  - `model_providers.<id>.base_url`
  - `model_providers.<id>.env_key`
  - `model_providers.<id>.wire_api="responses"`
- API Key 仅通过 `CCPANES_CODEX_API_KEY` 进程环境变量传递，不进入命令行参数或日志。
- 本地、WSL、SSH 三条 Codex 启动链路统一使用相同 Provider override。
- 未选择 Provider 时继续沿用用户本机 Codex 配置。

## 回归验证

- `cargo test -p cc-cli-adapters`：106 passed
- `cargo test -p cc-panes-core`：完整套件通过（866 passed，1 ignored）
- `cargo test -p cc-panes-daemon`：38 passed
- `cargo fmt --all -- --check`：通过
- `cargo clippy -p cc-cli-adapters -p cc-panes-core -- -D warnings`：通过
- Codex CLI 0.145.0 实机验证：
  - `app-server config/read` 的有效 `model_provider`、Base URL、`env_key` 与所选 Provider 一致
  - API Key 未出现在 argv
  - 使用该 Provider 发起 ephemeral 最小请求成功返回 `ROUTE_OK`