### PR TITLE
fix: preserve terminal IME state and sync theme controls

### DIFF
--- a/web/assets/index.css
+++ b/web/assets/index.css
@@ -153,6 +153,7 @@
 /* ===== Light 主题（默认）— Refined Developer Tool（冷调 off-white / 发丝边框 / 柔和 elevation）===== */
 :root {
   --radius: 0.5rem;
+  color-scheme: light;
 
   /* Elevation（柔和低透明）+ 顶部内高光 */
   --sh-sm: 0 1px 2px rgba(16, 24, 40, 0.06);
@@ -329,6 +330,7 @@
 
 /* ===== Dark 主题 — Refined Developer Tool（冷调近黑 / 发丝边框 / 明度分层 / 克制 elevation）===== */
 .dark {
+  color-scheme: dark;
   /* Elevation（暗色极克制）+ Linear 招牌顶部内高光 */
   --sh-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
   --sh-md: 0 4px 14px rgba(0, 0, 0, 0.42), 0 1px 2px rgba(0, 0, 0, 0.3);

--- a/web/components/panes/TerminalView.test.tsx
+++ b/web/components/panes/TerminalView.test.tsx
@@ -16,6 +16,7 @@ import { createTerminalLayoutScheduler } from "./terminalLayoutScheduler";
 import { TERMINAL_FIT_ALL_EVENT } from "./terminalFitEvents";
 import { terminalRestoreLaunchQueue } from "./terminalRestoreQueue";
 import TerminalView from "./TerminalView";
+import { attachTerminalImeGuard } from "./terminalImeGuard";
 
 /* ------------------------------------------------------------------ */
 /* xterm mock                                                          */
@@ -161,6 +162,17 @@ vi.mock("./terminalImeGuard", () => ({
   })),
   isLinuxWebKitImeEnvironment: vi.fn(() => false),
 }));
+
+vi.mock("./terminalClipboard", async () => {
+  const actual = await vi.importActual<typeof import("./terminalClipboard")>("./terminalClipboard");
+  return {
+    ...actual,
+    resolveTerminalPastePayload: vi.fn().mockResolvedValue({
+      kind: "text",
+      text: "pasted text",
+    }),
+  };
+});
 
 vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
   writeText: vi.fn().mockResolvedValue(undefined),
@@ -649,6 +661,25 @@ describe("TerminalView", () => {
       "ls -la\r",
       expect.objectContaining({ traceId: expect.any(Number) })
     );
+  });
+
+  it("does not clear native IME state around programmatic paste", async () => {
+    renderTerminalView();
+    const term = await lastTerm();
+    const textarea = term.textarea;
+    expect(textarea).not.toBeNull();
+
+    fireEvent.paste(textarea!, {
+      clipboardData: {
+        getData: vi.fn(() => "pasted text"),
+      },
+    });
+
+    await waitFor(() => expect(term.paste).toHaveBeenCalledWith("pasted text"));
+
+    const guardResults = vi.mocked(attachTerminalImeGuard).mock.results;
+    const guard = guardResults[guardResults.length - 1]?.value;
+    expect(guard?.clearNativeEditState).not.toHaveBeenCalled();
   });
 
   it("drops input typed before the session exists", async () => {

--- a/web/components/panes/TerminalView.tsx
+++ b/web/components/panes/TerminalView.tsx
@@ -1050,10 +1050,8 @@ const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
             kind,
             textLength: text.length,
           });
-          imeGuardRef.current?.clearNativeEditState("before-paste");
           term.focus();
           term.paste(text);
-          imeGuardRef.current?.clearNativeEditState("after-paste");
         };
 
         const pasteTerminalPayload = (clipboardData?: DataTransfer | null) => {

--- a/web/components/panes/terminalImeGuard.test.ts
+++ b/web/components/panes/terminalImeGuard.test.ts
@@ -367,7 +367,7 @@ describe("terminal IME guard", () => {
     guard.dispose();
   });
 
-  it("resets stuck composition state on paste cleanup so later IME input still forwards", () => {
+  it("resets guard composition state after explicit native edit cleanup", () => {
     const textarea = document.createElement("textarea");
     const terminal = { input: vi.fn() };
     const guard = attachTerminalImeGuard({
@@ -377,15 +377,14 @@ describe("terminal IME guard", () => {
       now: () => 1000,
     });
 
-    // 组合开始后被粘贴打断，WebKitGTK 此后不再发 compositionend（issue #41）。
+    // 组合开始后被显式清理打断，WebKitGTK 此后可能不再发 compositionend（issue #41）。
     textarea.dispatchEvent(new CompositionEvent("compositionstart", {
       data: "",
       bubbles: true,
       cancelable: true,
       composed: true,
     }));
-    guard.clearNativeEditState("before-paste");
-    guard.clearNativeEditState("after-paste");
+    guard.clearNativeEditState();
 
     // 之后的中文上屏没有新的 compositionstart，guard 必须按 malformed
     // composition 接管转发，而不是因残留的 composing 标志放行（放行后
@@ -438,13 +437,12 @@ describe("terminal IME guard", () => {
       guard.dispose();
     });
 
-    it("still clears the document selection for the IME workaround reasons", () => {
+    it("clears the document selection for explicit cleanup", () => {
       const { removeAllRanges, guard } = setupGuard();
 
-      guard.clearNativeEditState("before-paste");
       guard.clearNativeEditState();
 
-      expect(removeAllRanges).toHaveBeenCalledTimes(2);
+      expect(removeAllRanges).toHaveBeenCalledTimes(1);
       guard.dispose();
     });
   });

--- a/web/test/colorGuard.test.ts
+++ b/web/test/colorGuard.test.ts
@@ -184,4 +184,9 @@ describe("direct color guard", () => {
       ].join("\n"),
     ).toEqual([]);
   });
+
+  it("原生表单控件应随主题使用对应的 color-scheme", () => {
+    expect(themeBlock(indexCss, ":root")).toMatch(/color-scheme:\s*light\s*;/);
+    expect(themeBlock(indexCss, ".dark")).toMatch(/color-scheme:\s*dark\s*;/);
+  });
 });


### PR DESCRIPTION
## Summary
修复终端粘贴过程中的输入法状态丢失问题，并让原生表单控件跟随亮色/暗色主题。

## Changes
- 移除终端程序化粘贴前后的原生编辑状态清理，避免破坏 IME 上下文。
- 保留显式原生编辑状态清理时的 IME guard 状态重置，并补充回归测试。
- 为亮色和暗色主题设置对应的 `color-scheme`，补充主题断言。

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run test:run`（355 个测试文件，3320 个测试通过）
- [x] `npm run build`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [ ] `cargo clippy --workspace -- -D warnings`：基线在 `cc-panes-daemon/src/server.rs:1266` 触发 `clippy::collapsible_match`，与本 PR 改动无关。

## Screenshots
不适用。