### PR TITLE
feat: consolidate settings and dock orchestration

### DIFF
--- a/src-tauri/src/services/orchestrator_service.rs
+++ b/src-tauri/src/services/orchestrator_service.rs
@@ -13186,8 +13186,20 @@ mod tests {
 
         drop(first);
 
-        let second = bind_non_inheritable_listener(addr).expect("rebind fixed port");
-        assert_eq!(second.local_addr().expect("second listener addr"), addr);
+        for attempt in 0..=20 {
+            match bind_non_inheritable_listener(addr) {
+                Ok(second) => {
+                    assert_eq!(second.local_addr().expect("second listener addr"), addr);
+                    return;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AddrInUse && attempt < 20 => {
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+                Err(error) => panic!("rebind fixed port: {error}"),
+            }
+        }
+
+        unreachable!("bounded listener rebind loop must return or panic");
     }
 
     #[cfg(windows)]

--- a/web/components/home/HomeGettingStarted.test.tsx
+++ b/web/components/home/HomeGettingStarted.test.tsx
@@ -3,7 +3,12 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { skillService } from "@/services/skillService";
 import { useActivityBarStore } from "@/stores/useActivityBarStore";
-import { useDialogStore, useOrchestratorStore, useWorkspacesStore } from "@/stores";
+import {
+  useDialogStore,
+  useOrchestratorStore,
+  useRightDockStore,
+  useWorkspacesStore,
+} from "@/stores";
 import HomeGettingStarted from "./HomeGettingStarted";
 
 describe("HomeGettingStarted", () => {
@@ -18,6 +23,7 @@ describe("HomeGettingStarted", () => {
       orchestrationOverlayOpen: false,
     });
     useDialogStore.setState({ onboardingOpen: false });
+    useRightDockStore.setState({ visible: false, activeView: "git" });
     useWorkspacesStore.setState({ workspaces: [] });
     useOrchestratorStore.setState({ bindings: [] });
   });
@@ -70,7 +76,11 @@ describe("HomeGettingStarted", () => {
     await screen.findByText("0 / 5 已完成");
 
     fireEvent.click(screen.getByText("打开编排"));
-    expect(useActivityBarStore.getState().orchestrationOverlayOpen).toBe(true);
+    expect(useActivityBarStore.getState().orchestrationOverlayOpen).toBe(false);
+    expect(useRightDockStore.getState()).toMatchObject({
+      visible: true,
+      activeView: "orchestration",
+    });
 
     fireEvent.click(screen.getByText("浏览 Skills"));
     expect(useActivityBarStore.getState().appViewMode).toBe("resources");

--- a/web/components/onboarding/SetupGuideChecklist.test.tsx
+++ b/web/components/onboarding/SetupGuideChecklist.test.tsx
@@ -1,9 +1,12 @@
 import "@/i18n";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { skillService } from "@/services/skillService";
 import {
+  useActivityBarStore,
+  useDialogStore,
   useOrchestratorStore,
+  useRightDockStore,
   useWorkspacesStore,
 } from "@/stores";
 import type { InstalledUserSkill, TaskBinding, Workspace } from "@/types";
@@ -47,7 +50,24 @@ describe("SetupGuideChecklist", () => {
     localStorage.clear();
     useWorkspacesStore.setState({ workspaces: [] });
     useOrchestratorStore.setState({ bindings: [] });
+    useActivityBarStore.setState({ orchestrationOverlayOpen: false });
+    useRightDockStore.setState({ visible: false, activeView: "git" });
     vi.spyOn(skillService, "listUserSkills").mockResolvedValue([]);
+  });
+
+  it("opens orchestration in the right dock from the checklist", async () => {
+    useActivityBarStore.setState({ orchestrationOverlayOpen: true });
+    useDialogStore.setState({ settingsOpen: true });
+    render(<SetupGuideChecklist />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Open orchestration|打开编排/i }));
+
+    expect(useDialogStore.getState().settingsOpen).toBe(false);
+    expect(useActivityBarStore.getState().orchestrationOverlayOpen).toBe(false);
+    expect(useRightDockStore.getState()).toMatchObject({
+      visible: true,
+      activeView: "orchestration",
+    });
   });
 
   it("shows every core workflow item as pending for a new user", async () => {

--- a/web/components/onboarding/SetupGuideChecklist.tsx
+++ b/web/components/onboarding/SetupGuideChecklist.tsx
@@ -9,6 +9,7 @@ import {
   useOrchestratorStore,
   useWorkspacesStore,
 } from "@/stores";
+import { MODULE_REGISTRY } from "@/modules/registry";
 import { cn } from "@/lib/utils";
 import {
   ONBOARDING_MULTI_LAUNCH_KEY,
@@ -56,7 +57,7 @@ function openOnboarding(): void {
 
 function openOrchestration(): void {
   useDialogStore.getState().closeSettings();
-  useActivityBarStore.getState().openOrchestrationOverlay();
+  MODULE_REGISTRY.find((module) => module.id === "orchestration")?.open("rightDock");
 }
 
 function openSkills(): void {

--- a/web/components/sidebar/OrchestratorView.test.tsx
+++ b/web/components/sidebar/OrchestratorView.test.tsx
@@ -2,7 +2,7 @@ import "@/i18n";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import OrchestratorView from "./OrchestratorView";
-import { useActivityBarStore, useOrchestratorStore } from "@/stores";
+import { useOrchestratorStore } from "@/stores";
 import type { TaskBinding } from "@/types";
 
 vi.mock("./OrchestratorFilterBar", () => ({ default: () => <div>filter-bar-stub</div> }));
@@ -106,13 +106,6 @@ describe("OrchestratorView", () => {
     // one call on mount, one on click
     fireEvent.click(screen.getByRole("button", { name: /Refresh|刷新/i }));
     expect(loadBindings).toHaveBeenCalledTimes(2);
-  });
-
-  it("opens the orchestration overlay from the maximize button", () => {
-    const spy = vi.spyOn(useActivityBarStore.getState(), "openOrchestrationOverlay");
-    render(<OrchestratorView onOpenTerminal={vi.fn()} />);
-    fireEvent.click(screen.getByRole("button", { name: "Open overlay" }));
-    expect(spy).toHaveBeenCalled();
   });
 
   it("renders the filter bar without a dispatch composer", () => {

--- a/web/components/sidebar/OrchestratorView.tsx
+++ b/web/components/sidebar/OrchestratorView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback } from "react";
-import { Workflow, RefreshCw, Maximize2, List, ListTree } from "lucide-react";
-import { useActivityBarStore, useOrchestratorStore } from "@/stores";
+import { Workflow, RefreshCw, List, ListTree } from "lucide-react";
+import { useOrchestratorStore } from "@/stores";
 import { useTranslation } from "react-i18next";
 import OrchestratorFilterBar from "./OrchestratorFilterBar";
 import OrchestratorTaskCard from "./OrchestratorTaskCard";
@@ -50,17 +50,8 @@ export default function OrchestratorView({
         <span className="min-w-0 truncate text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--app-text-secondary)" }}>
           {t("rightDock.orchestration", { defaultValue: "Orchestration" })}
         </span>
-        {!compact && (
-          <button
-            className="ml-auto shrink-0 rounded p-1 transition-colors hover:bg-[var(--app-hover)]"
-            onClick={() => useActivityBarStore.getState().openOrchestrationOverlay()}
-            title="Open overlay"
-          >
-            <Maximize2 className="w-3.5 h-3.5" style={{ color: "var(--app-text-tertiary)" }} />
-          </button>
-        )}
         <button
-          className={`${compact ? "ml-auto" : ""} shrink-0 rounded p-1 transition-colors hover:bg-[var(--app-hover)]`}
+          className="ml-auto shrink-0 rounded p-1 transition-colors hover:bg-[var(--app-hover)]"
           onClick={handleRefresh}
           title={t("refresh")}
         >

--- a/web/components/tips/featureTipRegistry.test.ts
+++ b/web/components/tips/featureTipRegistry.test.ts
@@ -64,11 +64,15 @@ describe("扩容的六条 tip", () => {
     }
   });
 
-  it("派工编排：试试看打开任务编排面板；模块关掉或没有项目时不候选", () => {
+  it("派工编排：试试看打开右侧坞任务编排；模块关掉或没有项目时不候选", () => {
     expect(tip("dispatch-orchestration").eligible?.()).toBe(true);
 
     tip("dispatch-orchestration").tryAction?.();
-    expect(useActivityBarStore.getState().orchestrationOverlayOpen).toBe(true);
+    expect(useActivityBarStore.getState().orchestrationOverlayOpen).toBe(false);
+    expect(useRightDockStore.getState()).toMatchObject({
+      visible: true,
+      activeView: "orchestration",
+    });
 
     useWorkspacesStore.setState({ workspaces: [{ ...workspace, projects: [] }] });
     expect(tip("dispatch-orchestration").eligible?.()).toBe(false);

--- a/web/components/tips/featureTipRegistry.tsx
+++ b/web/components/tips/featureTipRegistry.tsx
@@ -95,6 +95,10 @@ function openSkillsPage(): void {
   activity.setAppViewMode("resources");
 }
 
+function openOrchestrationModule(): void {
+  MODULE_REGISTRY.find((module) => module.id === "orchestration")?.open("rightDock");
+}
+
 function shortcutTip(
   definition: Omit<FeatureTipDefinition, "tryAction" | "eligible"> & { actionId: string },
 ): FeatureTipDefinition {
@@ -151,7 +155,7 @@ export const FEATURE_TIPS: readonly FeatureTipDefinition[] = [
     guidePath: "docs/guide/12-leader-worker.md",
     visual: DispatchOrchestrationVisual,
     // 任务编排面板就是盯 worker 的地方；没有项目就没有可派的活。
-    tryAction: () => useActivityBarStore.getState().openOrchestrationOverlay(),
+    tryAction: openOrchestrationModule,
     eligible: () => isModuleEnabled("orchestration") && hasAnyProject(),
     weight: 4,
   },

--- a/web/stores/useThemeStore.test.ts
+++ b/web/stores/useThemeStore.test.ts
@@ -51,11 +51,10 @@ describe("useThemeStore", () => {
 
     it("应更新 localStorage", () => {
       useThemeStore.setState({ isDark: false });
-      const setItemSpy = vi.spyOn(window.localStorage, "setItem");
 
       useThemeStore.getState().toggleTheme();
 
-      expect(setItemSpy).toHaveBeenCalledWith("theme", "dark");
+      expect(window.localStorage.getItem("theme")).toBe("dark");
     });
 
     it("切换到 dark 时应在 DOM 添加 dark class", () => {


### PR DESCRIPTION
## Summary

- consolidate the settings experience and CLI/provider configuration UI
- keep task orchestration in the right dock and remove redundant overlay entry points
- stabilize the Node 20 theme persistence test and Linux listener rebind test

## Verification

- `npm run test:run` (412 files, 4052 tests)
- `npx tsc --noEmit`
- `npm run build`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- Node 20: `web/stores/useThemeStore.test.ts` (8 tests)