### PR TITLE
fix(ci): 统一发布草稿并修复文档站构建

### DIFF
--- a/.github/release-installation.md
+++ b/.github/release-installation.md
@@ -1,0 +1,30 @@
+
+---
+
+## macOS 安装说明
+
+由于应用未经 Apple 签名，macOS 可能提示"文件已损坏"或"无法验证开发者"。请使用以下任一方式解决：
+
+**方式一：系统设置（全版本可用）**
+先双击打开一次（会被拦截），然后打开"系统设置 → 隐私与安全性"，在底部找到被阻止的应用，点击"仍要打开"。
+
+**方式二：终端命令**
+```bash
+xattr -cr /Applications/CC-Panes.app
+```
+
+> 注意：旧教程里的"右键 → 打开"绕过方式在 macOS 15 Sequoia 已被系统移除，请使用上面两种方式。
+
+## Linux 安装说明
+
+**Deb 包（Ubuntu/Debian）：**
+```bash
+sudo dpkg -i cc-panes_*.deb
+sudo apt-get install -f  # 安装缺少的依赖
+```
+
+**AppImage：**
+```bash
+chmod +x cc-panes_*.AppImage
+./cc-panes_*.AppImage
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,41 @@ jobs:
       - name: Validate Chinese release notes
         run: node .github/scripts/extract-changelog.mjs "${{ steps.tag.outputs.version }}" > /dev/null
 
+  prepare-release:
+    name: Prepare one release draft
+    runs-on: ubuntu-latest
+    needs: validate-version
+    permissions:
+      contents: write
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create or reuse the release draft
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json apiUrl --jq .apiUrl > release-api-url.txt 2> release-query-error.txt; then
+            if ! grep -qi 'release not found' release-query-error.txt; then
+              cat release-query-error.txt >&2
+              exit 1
+            fi
+            node .github/scripts/extract-changelog.mjs "${TAG#v}" > release-notes.txt
+            cat .github/release-installation.md >> release-notes.txt
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --draft \
+              --title "CC-Panes $TAG" --notes-file release-notes.txt
+            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json apiUrl --jq .apiUrl > release-api-url.txt
+          fi
+          RELEASE_ID=$(gh api "$(cat release-api-url.txt)" --jq .id)
+          [[ "$RELEASE_ID" =~ ^[0-9]+$ ]]
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build (${{ matrix.label }})
     runs-on: ${{ matrix.platform }}
-    needs: validate-version
+    needs: [validate-version, prepare-release]
     permissions:
       contents: write
     strategy:
@@ -178,46 +209,8 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: v__VERSION__
-          releaseName: "CC-Panes v__VERSION__"
-          releaseBody: |
-            See the [CHANGELOG](https://github.com/wuxiran/cc-pane/blob/main/CHANGELOG.md) for details.
-
-            ---
-
-            ## macOS 安装说明
-
-            由于应用未经 Apple 签名，macOS 可能提示"文件已损坏"或"无法验证开发者"。请使用以下任一方式解决：
-
-            **方式一：系统设置（全版本可用）**
-            先双击打开一次（会被拦截），然后打开"系统设置 → 隐私与安全性"，在底部找到被阻止的应用，点击"仍要打开"。
-
-            **方式二：终端命令**
-            ```bash
-            xattr -cr /Applications/CC-Panes.app
-            ```
-
-            > 注意：旧教程里的"右键 → 打开"绕过方式在 macOS 15 Sequoia 已被系统移除，请使用上面两种方式。
-
-            ## Linux 安装说明
-
-            **Deb 包（Ubuntu/Debian）：**
-            ```bash
-            sudo dpkg -i cc-panes_*.deb
-            sudo apt-get install -f  # 安装缺少的依赖
-            ```
-
-            **AppImage：**
-            ```bash
-            chmod +x cc-panes_*.AppImage
-            ./cc-panes_*.AppImage
-            ```
-          # Keep the new version private until all packages and updater metadata are ready.
-          releaseDraft: true
-          # tag 含 `-`（如 v0.12.0-beta.1）自动标 prerelease：GitHub 的 releases/latest
-          # 排除 prerelease，稳定版用户的 updater（指向 latest/download/latest.json）
-          # 不会被推 beta——beta 只面向手动下载者。
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          # All platforms upload to the one prepared ID; parallel draft creation can split assets.
+          releaseId: ${{ needs.prepare-release.outputs.release_id }}
           # latest.json 绝不能由五个并行 job 各自生成上传：tauri-action 的
           # merge 是无锁 read-modify-write，后完成者用旧快照覆盖先完成者
           # （v0.12.1 实测线上清单只剩 linux + windows-arm64 两平台，
@@ -352,7 +345,7 @@ jobs:
   mobile-apk:
     name: Build Mobile APK
     runs-on: ubuntu-24.04
-    needs: validate-version
+    needs: [validate-version, prepare-release]
     permissions:
       contents: write
     steps:
@@ -386,14 +379,6 @@ jobs:
         run: |
           APK_NAME="cc-panes-mobile_${{ steps.tag.outputs.version }}.apk"
           cp cc-panes-mobile/build/app/outputs/flutter-apk/app-release.apk "$APK_NAME"
-          # tauri-action 的 build job 负责创建 release；这里等它就绪后上传。
-          # 上限 30 分钟：实测 windows 构建 16 分钟+ 才发布 release，10 分钟等不到（v0.12.0-beta.1 失败一次）
-          for i in $(seq 1 180); do
-            if gh release view "v${{ steps.tag.outputs.version }}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-              break
-            fi
-            sleep 10
-          done
           gh release upload "v${{ steps.tag.outputs.version }}" "$APK_NAME" --repo "$GITHUB_REPOSITORY" --clobber
 
   publish-release:

--- a/docs/diagnostics/performance-records.md
+++ b/docs/diagnostics/performance-records.md
@@ -51,7 +51,7 @@ resyncCount 的增量判断，不应单凭这个标志认定后台一直在重�
 2. 保留 performance 目录所有 JSONL 文件，并一起保留同级应用日志。
    如果整个程序闪退，同时保留 `%USERPROFILE%\.cc-panes\crash.log`（开发版为
    `.cc-panes-dev`），按发生时间核对 Windows 应用程序事件；panic 与资源耗尽
-   需要分别取证。已知案例见 [Grok 全屏恢复与对话闪退](../bugs/grok-fullscreen-recovery-and-transcript-crash.md)。
+   需要分别取证。已知案例见 [Grok 全屏恢复与对话闪退](https://github.com/wuxiran/cc-pane/blob/main/docs/bugs/grok-fullscreen-recovery-and-transcript-crash.md)。
 3. 运行摘要工具，快速查看各进程内存首值/末值/峰值、CPU、积压和事件计数：
 
 ```powershell

--- a/docs/feedback-channels.md
+++ b/docs/feedback-channels.md
@@ -63,10 +63,10 @@ toastErr(t("popOutFailed", { ns: "panes", error: String(err) }));
 
 ### Toaster 挂载与位置
 
-- 主窗口：`web/components/layout/AppShell.tsx`，`position="bottom-center"`，`offset={{ bottom: 40 }}`。
+- 主窗口：`web/components/layout/AppShell.tsx`，`position="bottom-center"`，`offset={TOASTER_OFFSET_MAIN}`。
   理由：右下是通知中心卡片栈（`fixed bottom-11 right-3`），顶部有 TitleBar 与 Banner，底部有 28px StatusBar；
   底部居中 + 40px offset（28px StatusBar + 12px 间距）三者都不遮挡。
-- ccchan 浮窗：`web/ccchan/CCChanApp.tsx`，同样 `bottom-center`，`offset={{ bottom: 12 }}`（浮窗无 StatusBar）。
+- ccchan 浮窗：`web/ccchan/CCChanApp.tsx`，同样 `bottom-center`，`offset={TOASTER_OFFSET_CCCHAN}`（浮窗无 StatusBar）。
 - 位置与 offset 常量由 `web/lib/feedback.ts` 导出（`TOASTER_POSITION` / `TOASTER_OFFSET_MAIN` / `TOASTER_OFFSET_CCCHAN`），不写裸 CSS hack。
 
 ### 通知中心


### PR DESCRIPTION
## Summary

并行平台构建可能创建多个同名草稿，导致安装包、Android 包和更新清单分散在不同 Release。新增统一的草稿准备步骤，并将同一个 Release ID 传给所有平台构建；Android 上传也在草稿就绪后执行。

同时修正文档站的两个构建错误：JSX 双花括号示例被当成 Vue 插值，以及排障页面链接到了站点排除的目录。

## Changes

- 发布前统一创建或复用草稿；查询发生网络错误时失败退出，不误建新草稿。
- Tauri 各平台使用明确的 `releaseId`，移动端无需再等待第一个桌面任务创建 Release。
- 安装说明独立为共享 Markdown 文件，继续保留最终提交 CI 和全部工件完成后的公开发布条件。
- 反馈示例使用已有偏移常量，故障案例使用可访问的 GitHub 源文件链接。

## Test Plan

- [x] Windows `npm run docs:build`，退出码 0。
- [x] YAML 依赖关系与 Bash 语法检查。
- [x] 模拟草稿不存在、已存在、API 查询失败三种场景，均通过。
- [x] `git diff --check`。
- [ ] 更新后的整条 Release 流水线在合并后下一版本验证。
